### PR TITLE
Feature/cgal

### DIFF
--- a/buildscripts/build_stack.sh
+++ b/buildscripts/build_stack.sh
@@ -85,7 +85,7 @@ build_lib ECBUILD ecbuild jcsda 3.1.0.jcsda2
 build_lib HDF5 hdf5 1.10.5
 build_lib PNETCDF pnetcdf 1.11.2
 build_lib NETCDF netcdf 4.7.0 4.4.5 4.3.0
-build_lib NCCMP nccmp 1.8.2.1
+build_lib NCCMP nccmp 1.8.6.5
 build_lib ECKIT eckit jcsda 1.4.0.jcsda3
 build_lib FCKIT fckit jcsda develop
 build_lib ATLAS atlas ecmwf 0.19.1

--- a/buildscripts/build_stack.sh
+++ b/buildscripts/build_stack.sh
@@ -79,7 +79,7 @@ build_lib BOOST_HDRS boost 1.68.0 headers-only
 build_lib EIGEN3 eigen 3.3.5
 build_lib BUFRLIB bufrlib master
 build_lib ECBUILD ecbuild jcsda 3.1.0.jcsda2
-build_lib CGAL cgal 5.0
+build_lib CGAL cgal 5.0.2
 
 #----------------------
 # These must be rebuilt for each MPI implementation

--- a/buildscripts/build_stack.sh
+++ b/buildscripts/build_stack.sh
@@ -79,6 +79,7 @@ build_lib BOOST_HDRS boost 1.68.0 headers-only
 build_lib EIGEN3 eigen 3.3.5
 build_lib BUFRLIB bufrlib master
 build_lib ECBUILD ecbuild jcsda 3.1.0.jcsda2
+build_lib CGAL cgal 5.0
 
 #----------------------
 # These must be rebuilt for each MPI implementation

--- a/buildscripts/config/config_cheyenne.sh
+++ b/buildscripts/config/config_cheyenne.sh
@@ -2,7 +2,7 @@
 
 # Compiler/MPI combination
 export JEDI_COMPILER="gnu/7.3.0"
-export MPI="openmpi/3.1.3"
+export JEDI_MPI="openmpi/3.1.3"
 
 # This tells jedi-stack how you want to build the compiler and mpi modules
 # valid options include:
@@ -34,7 +34,7 @@ export       STACK_BUILD_SZIP=Y
 export    STACK_BUILD_UDUNITS=Y
 export       STACK_BUILD_ZLIB=Y
 export     STACK_BUILD_LAPACK=Y
-export    STACK_BOOST_HEADERS=Y
+export STACK_BUILD_BOOST_HDRS=Y
 export     STACK_BUILD_EIGEN3=Y
 export       STACK_BUILD_HDF5=Y
 export    STACK_BUILD_PNETCDF=Y
@@ -58,7 +58,7 @@ export        STACK_BUILD_JASPER=N
 export     STACK_BUILD_ARMADILLO=N
 export        STACK_BUILD_XERCES=N
 export        STACK_BUILD_TKDIFF=N
-export          STACK_BOOST_FULL=N
+export    STACK_BUILD_BOOST_FULL=N
 export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N

--- a/buildscripts/config/config_cheyenne.sh
+++ b/buildscripts/config/config_cheyenne.sh
@@ -63,4 +63,5 @@ export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N
 export          STACK_BUILD_TAU2=N
+export          STACK_BUILD_CGAL=N
 

--- a/buildscripts/config/config_container-clang-mpich-dev.sh
+++ b/buildscripts/config/config_container-clang-mpich-dev.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export COMPILER="clang/8.0.0"
-export MPI="mpich/3.3.1"
+export JEDI_COMPILER="clang/8.0.0"
+export JEDI_MPI="mpich/3.3.1"
 
 # This tells jedi-stack how you want to build the compiler and mpi modules
 # valid options include:
@@ -34,7 +34,7 @@ export       STACK_BUILD_SZIP=Y
 export    STACK_BUILD_UDUNITS=Y
 export       STACK_BUILD_ZLIB=Y
 export     STACK_BUILD_LAPACK=Y
-export    STACK_BOOST_HEADERS=Y
+export STACK_BUILD_BOOST_HDRS=Y
 export     STACK_BUILD_EIGEN3=Y
 export       STACK_BUILD_HDF5=Y
 export    STACK_BUILD_PNETCDF=Y
@@ -58,7 +58,7 @@ export        STACK_BUILD_JASPER=N
 export     STACK_BUILD_ARMADILLO=N
 export        STACK_BUILD_XERCES=N
 export        STACK_BUILD_TKDIFF=N
-export          STACK_BOOST_FULL=N
+export    STACK_BUILD_BOOST_FULL=N
 export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N

--- a/buildscripts/config/config_container-clang-mpich-dev.sh
+++ b/buildscripts/config/config_container-clang-mpich-dev.sh
@@ -63,4 +63,5 @@ export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N
 export          STACK_BUILD_TAU2=N
+export          STACK_BUILD_CGAL=N
 

--- a/buildscripts/config/config_container-gnu-openmpi-dev.sh
+++ b/buildscripts/config/config_container-gnu-openmpi-dev.sh
@@ -64,4 +64,5 @@ export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N
 export          STACK_BUILD_TAU2=N
+export          STACK_BUILD_CGAL=N
 

--- a/buildscripts/config/config_container-gnu-openmpi-dev.sh
+++ b/buildscripts/config/config_container-gnu-openmpi-dev.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export COMPILER="gnu/7.3.0"
-export MPI="openmpi/3.1.2"
-#export MPI="mpich/3.2.1"
+export JEDI_COMPILER="gnu/7.3.0"
+export JEDI_MPI="openmpi/3.1.2"
+#export JEDI_MPI="mpich/3.2.1"
 
 # This tells jedi-stack how you want to build the compiler and mpi modules
 # valid options include:
@@ -35,7 +35,7 @@ export       STACK_BUILD_SZIP=Y
 export    STACK_BUILD_UDUNITS=Y
 export       STACK_BUILD_ZLIB=Y
 export     STACK_BUILD_LAPACK=Y
-export    STACK_BOOST_HEADERS=Y
+export STACK_BUILD_BOOST_HDRS=Y
 export     STACK_BUILD_EIGEN3=Y
 export       STACK_BUILD_HDF5=Y
 export    STACK_BUILD_PNETCDF=Y
@@ -59,7 +59,7 @@ export        STACK_BUILD_JASPER=N
 export     STACK_BUILD_ARMADILLO=N
 export        STACK_BUILD_XERCES=N
 export        STACK_BUILD_TKDIFF=N
-export          STACK_BOOST_FULL=N
+export    STACK_BUILD_BOOST_FULL=N
 export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N

--- a/buildscripts/config/config_container-intel-impi-dev.sh
+++ b/buildscripts/config/config_container-intel-impi-dev.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export COMPILER="intel/17.0.1"
-export MPI="impi/17.0.1"
+export JEDI_COMPILER="intel/17.0.1"
+export JEDI_MPI="impi/17.0.1"
 source /opt/intel/compilers_and_libraries/linux/bin/compilervars.sh intel64
 export PATH=/usr/local/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
@@ -39,7 +39,7 @@ export       STACK_BUILD_SZIP=Y
 export    STACK_BUILD_UDUNITS=Y
 export       STACK_BUILD_ZLIB=Y
 export     STACK_BUILD_LAPACK=N
-export    STACK_BOOST_HEADERS=Y
+export STACK_BUILD_BOOST_HDRS=Y
 export     STACK_BUILD_EIGEN3=Y
 export       STACK_BUILD_HDF5=Y
 export    STACK_BUILD_PNETCDF=Y
@@ -63,7 +63,7 @@ export        STACK_BUILD_JASPER=N
 export     STACK_BUILD_ARMADILLO=N
 export        STACK_BUILD_XERCES=N
 export        STACK_BUILD_TKDIFF=N
-export          STACK_BOOST_FULL=N
+export    STACK_BUILD_BOOST_FULL=N
 export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N

--- a/buildscripts/config/config_container-intel-impi-dev.sh
+++ b/buildscripts/config/config_container-intel-impi-dev.sh
@@ -68,3 +68,4 @@ export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N
 export          STACK_BUILD_TAU2=N
+export          STACK_BUILD_CGAL=N

--- a/buildscripts/config/config_custom.sh
+++ b/buildscripts/config/config_custom.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-#export COMPILER="gnu/7.4.0"
-#export MPI="openmpi/3.1.2"
+export JEDI_COMPILER="gnu/9.2.0"
+export JEDI_MPI="openmpi/4.0.1"
 #export MPI="mpich/3.2.1"
 
 #export COMPILER="intel/17.0.1"
 #export MPI="impi/17.0.1"
 
-export COMPILER="clang/6.0.1"
-export MPI="openmpi/3.1.2"
+#export JEDI_COMPILER="clang/6.0.1"
+#export JEDI_MPI="openmpi/3.1.2"
 
 # This tells jedi-stack how you want to build the compiler and mpi modules
 # valid options include:
@@ -33,6 +33,7 @@ export MAKE_VERBOSE=Y
 export   MAKE_CLEAN=N
 export DOWNLOAD_ONLY=N
 export STACK_EXIT_ON_FAIL=Y
+export WGET="wget -nv"
 
 # Minimal JEDI Stack
 export      STACK_BUILD_CMAKE=N
@@ -40,21 +41,21 @@ export       STACK_BUILD_SZIP=N
 export    STACK_BUILD_UDUNITS=N
 export       STACK_BUILD_ZLIB=N
 export     STACK_BUILD_LAPACK=N
-export    STACK_BOOST_HEADERS=N
+export STACK_BUILD_BOOST_HDRS=N
 export     STACK_BUILD_EIGEN3=N
 export       STACK_BUILD_HDF5=N
 export    STACK_BUILD_PNETCDF=N
 export     STACK_BUILD_NETCDF=N
 export      STACK_BUILD_NCCMP=N
 export        STACK_BUILD_NCO=N
-export    STACK_BUILD_ECBUILD=Y
+export    STACK_BUILD_ECBUILD=N
 export      STACK_BUILD_ECKIT=N
 export      STACK_BUILD_FCKIT=N
 export      STACK_BUILD_ATLAS=N
 export        STACK_BUILD_ODB=N
-export        STACK_BUILD_ODC=Y
+export        STACK_BUILD_ODC=N
 export    STACK_BUILD_ODYSSEY=Y
-export    STACK_BUILD_BUFRLIB=N
+export    STACK_BUILD_BUFRLIB=Y
 
 # Optional Additions
 export           STACK_BUILD_PIO=N
@@ -64,9 +65,9 @@ export        STACK_BUILD_JASPER=N
 export     STACK_BUILD_ARMADILLO=N
 export        STACK_BUILD_XERCES=N
 export        STACK_BUILD_TKDIFF=N
-export          STACK_BOOST_FULL=N
+export    STACK_BUILD_BOOST_FULL=N
 export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
-export     STACK_BUILD_PDTOOLKIT=Y
+export     STACK_BUILD_PDTOOLKIT=N
 export          STACK_BUILD_TAU2=N
 

--- a/buildscripts/config/config_custom.sh
+++ b/buildscripts/config/config_custom.sh
@@ -70,4 +70,5 @@ export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N
 export          STACK_BUILD_TAU2=N
+export          STACK_BUILD_CGAL=N
 

--- a/buildscripts/config/config_gentoo.sh
+++ b/buildscripts/config/config_gentoo.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+#Cross-platform get number of processors
+if [ -z $NUM_PROCS ]; then
+    case $(uname -s) in
+        Linux*) NUM_PROCS=$(grep -c ^processor /proc/cpuinfo);;
+        Darwin*) NUM_PROCS=$(sysctl -n hw.logicalcpu);;
+        *) NUM_PROCS=1
+    esac
+fi
+
+# Compiler/MPI combination
+export JEDI_COMPILER=${JEDI_COMPILER:-"intel/20.0"}
+export JEDI_MPI=${JEDI_MPI:-"impi/20.0"}
+export JEDI_STACK_DISABLE_COMPILER_VERSION_CHECK=1
+
+# This tells jedi-stack how you want to build the compiler and mpi modules
+# valid options include:
+# native-module: load a pre-existing module (common for HPC systems)
+# native-pkg: use pre-installed executables located in /usr/bin or /usr/local/bin,
+#             as installed by package managers like apt-get or homebrew.
+#             This is a common option for, e.g., gcc/g++/gfortran
+# from-source: This is to build from source
+export COMPILER_BUILD="native-module"
+if [[ "$JEDI_MPI" == "impi"* ]]; then
+    export MPI_BUILD="native-module"
+else
+    export MPI_BUILD="from-source"
+fi
+
+# For nccmp. This magically fixes the make install command.
+export MKDIR_P="mkdir -p"
+
+# Build options
+export PREFIX=${JEDI_OPT}
+export USE_SUDO=N
+export PKGDIR=pkg
+export LOGDIR=buildscripts/log
+export OVERWRITE=Y
+export NTHREADS=${NUM_PROCS}
+export   MAKE_CHECK=N
+export MAKE_VERBOSE=Y
+export   MAKE_CLEAN=N
+export DOWNLOAD_ONLY=F
+export STACK_EXIT_ON_FAIL=T
+export WGET="wget -nv"
+
+export SZIP_ROOT=/usr
+export ZLIB_ROOT=/usr
+
+# Minimal JEDI Stack
+export      STACK_BUILD_CMAKE=N
+export       STACK_BUILD_SZIP=N
+export    STACK_BUILD_UDUNITS=N
+export       STACK_BUILD_ZLIB=N
+export     STACK_BUILD_LAPACK=N
+export STACK_BUILD_BOOST_HDRS=N
+export     STACK_BUILD_EIGEN3=N
+export       STACK_BUILD_HDF5=Y
+export    STACK_BUILD_PNETCDF=Y
+export     STACK_BUILD_NETCDF=Y
+export      STACK_BUILD_NCCMP=N
+export        STACK_BUILD_NCO=N
+export    STACK_BUILD_ECBUILD=N
+export      STACK_BUILD_ECKIT=N
+export      STACK_BUILD_FCKIT=N
+export        STACK_BUILD_ODB=Y
+export        STACK_BUILD_ODC=Y
+export    STACK_BUILD_ODYSSEY=Y
+export    STACK_BUILD_BUFRLIB=Y
+
+# Optional Additions
+export           STACK_BUILD_PIO=Y
+export        STACK_BUILD_PYJEDI=N
+export      STACK_BUILD_NCEPLIBS=N
+export        STACK_BUILD_JASPER=N
+export     STACK_BUILD_ARMADILLO=N
+export        STACK_BUILD_XERCES=N
+export        STACK_BUILD_TKDIFF=N
+export    STACK_BUILD_BOOST_FULL=N
+export          STACK_BUILD_ESMF=N
+export      STACK_BUILD_BASELIBS=N

--- a/buildscripts/config/config_gentoo.sh
+++ b/buildscripts/config/config_gentoo.sh
@@ -80,3 +80,4 @@ export        STACK_BUILD_TKDIFF=N
 export    STACK_BUILD_BOOST_FULL=N
 export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
+export          STACK_BUILD_CGAL=N

--- a/buildscripts/config/config_mac.sh
+++ b/buildscripts/config/config_mac.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export COMPILER="clang/10.0.0"
-#export COMPILER="clang/10.0.1"
-export MPI="openmpi/3.1.2"
-#export MPI="mpich/3.3.1"
+export JEDI_COMPILER="clang/10.0.0"
+#export JEDI_COMPILER="clang/10.0.1"
+export JEDI_MPI="openmpi/3.1.2"
+#export JEDI_MPI="mpich/3.3.1"
 
 # This tells jedi-stack how you want to build the compiler and mpi modules
 # valid options include:
@@ -39,7 +39,7 @@ export       STACK_BUILD_SZIP=Y
 export    STACK_BUILD_UDUNITS=Y
 export       STACK_BUILD_ZLIB=Y
 export     STACK_BUILD_LAPACK=Y
-export    STACK_BOOST_HEADERS=Y
+export STACK_BUILD_BOOST_HDRS=Y
 export     STACK_BUILD_EIGEN3=Y
 export       STACK_BUILD_HDF5=Y
 export    STACK_BUILD_PNETCDF=Y
@@ -63,7 +63,7 @@ export        STACK_BUILD_JASPER=N
 export     STACK_BUILD_ARMADILLO=N
 export        STACK_BUILD_XERCES=N
 export        STACK_BUILD_TKDIFF=N
-export          STACK_BOOST_FULL=N
+export    STACK_BUILD_BOOST_FULL=N
 export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N

--- a/buildscripts/config/config_mac.sh
+++ b/buildscripts/config/config_mac.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export JEDI_COMPILER="clang/10.0.0"
-#export JEDI_COMPILER="clang/10.0.1"
-export JEDI_MPI="openmpi/3.1.2"
-#export JEDI_MPI="mpich/3.3.1"
+export JEDI_COMPILER="clang/11.0.0"
+#export JEDI_MPI="openmpi/3.1.2"
+export JEDI_MPI="mpich/3.3.1"
 
 # This tells jedi-stack how you want to build the compiler and mpi modules
 # valid options include:
@@ -56,7 +55,7 @@ export    STACK_BUILD_ODYSSEY=Y
 export    STACK_BUILD_BUFRLIB=Y
 
 # Optional Additions
-export           STACK_BUILD_PIO=N
+export           STACK_BUILD_PIO=Y
 export        STACK_BUILD_PYJEDI=N
 export      STACK_BUILD_NCEPLIBS=N
 export        STACK_BUILD_JASPER=N

--- a/buildscripts/config/config_mac.sh
+++ b/buildscripts/config/config_mac.sh
@@ -64,4 +64,5 @@ export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N
 export          STACK_BUILD_TAU2=N
+export          STACK_BUILD_CGAL=N
 

--- a/buildscripts/config/config_mac.sh
+++ b/buildscripts/config/config_mac.sh
@@ -15,9 +15,6 @@ export JEDI_MPI="mpich/3.3.1"
 export COMPILER_BUILD="native-pkg"
 export MPI_BUILD="from-source"
 
-# For nccmp. This magically fixes the make install command.
-export MKDIR_P="mkdir -p"
-
 # Build options
 export PREFIX=/opt/modules
 export USE_SUDO=Y

--- a/buildscripts/config/config_orion.sh
+++ b/buildscripts/config/config_orion.sh
@@ -2,7 +2,7 @@
 
 # Compiler/MPI combination
 export JEDI_COMPILER="intel/2019.5"
-export MPI="openmpi/4.0.2"
+export JEDI_MPI="openmpi/4.0.2"
 
 # This tells jedi-stack how you want to build the compiler and mpi modules
 # valid options include:
@@ -34,7 +34,7 @@ export       STACK_BUILD_SZIP=Y
 export    STACK_BUILD_UDUNITS=Y
 export       STACK_BUILD_ZLIB=Y
 export     STACK_BUILD_LAPACK=Y
-export    STACK_BOOST_HEADERS=Y
+export STACK_BUILD_BOOST_HDRS=Y
 export     STACK_BUILD_EIGEN3=Y
 export       STACK_BUILD_HDF5=Y
 export    STACK_BUILD_PNETCDF=Y
@@ -57,7 +57,7 @@ export        STACK_BUILD_JASPER=N
 export     STACK_BUILD_ARMADILLO=N
 export        STACK_BUILD_XERCES=N
 export        STACK_BUILD_TKDIFF=N
-export          STACK_BOOST_FULL=N
+export    STACK_BUILD_BOOST_FULL=N
 export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N

--- a/buildscripts/config/config_orion.sh
+++ b/buildscripts/config/config_orion.sh
@@ -61,5 +61,5 @@ export    STACK_BUILD_BOOST_FULL=N
 export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N
-export          STACK_BUILD_TAU2=N
+export          STACK_BUILD_CGAL=N
 

--- a/buildscripts/config/config_rhel7emc.sh
+++ b/buildscripts/config/config_rhel7emc.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export COMPILER="gnu/9.2.0"
-export MPI="openmpi/3.1.5"
-#export MPI="mpich/3.2.1"
+export JEDI_COMPILER="gnu/9.2.0"
+export JEDI_MPI="openmpi/3.1.5"
+#export JEDI_MPI="mpich/3.2.1"
 
 # This tells jedi-stack how you want to build the compiler and mpi modules
 # valid options include:
@@ -35,7 +35,7 @@ export       STACK_BUILD_SZIP=Y
 export    STACK_BUILD_UDUNITS=Y
 export       STACK_BUILD_ZLIB=Y
 export     STACK_BUILD_LAPACK=Y
-export    STACK_BOOST_HEADERS=Y
+export STACK_BUILD_BOOST_HDRS=Y
 export     STACK_BUILD_EIGEN3=Y
 export       STACK_BUILD_HDF5=Y
 export    STACK_BUILD_PNETCDF=Y
@@ -58,7 +58,7 @@ export        STACK_BUILD_JASPER=Y
 export     STACK_BUILD_ARMADILLO=N
 export        STACK_BUILD_XERCES=N
 export        STACK_BUILD_TKDIFF=N
-export          STACK_BOOST_FULL=N
+export    STACK_BUILD_BOOST_FULL=N
 export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N

--- a/buildscripts/config/config_rhel7emc.sh
+++ b/buildscripts/config/config_rhel7emc.sh
@@ -63,3 +63,4 @@ export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N
 export          STACK_BUILD_TAU2=N
+export          STACK_BUILD_CGAL=N

--- a/buildscripts/libs/build_atlas.sh
+++ b/buildscripts/libs/build_atlas.sh
@@ -45,6 +45,7 @@ cd ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}
 [[ -d $software ]] || git clone https://github.com/$source/$software.git
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+git fetch
 git checkout $version
 [[ -d build ]] && $SUDO rm -rf build
 mkdir -p build && cd build

--- a/buildscripts/libs/build_atlas.sh
+++ b/buildscripts/libs/build_atlas.sh
@@ -8,8 +8,8 @@ source=$1
 version=$2
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 [[ $USE_SUDO =~ [yYtT] ]] && export SUDO="sudo" || unset SUDO
 [[ $MAKE_VERBOSE =~ [yYtT] ]] && verb="VERBOSE=1" || unset verb
@@ -17,8 +17,8 @@ mpi=$(echo $MPI | sed 's/\//-/g')
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
-    module load jedi-$MPI
+    module load jedi-$JEDI_COMPILER
+    module load jedi-$JEDI_MPI
     module load ecbuild eckit fckit
     module list
     set -x

--- a/buildscripts/libs/build_baselibs.sh
+++ b/buildscripts/libs/build_baselibs.sh
@@ -6,14 +6,14 @@ name="baselibs"
 version=$1
 
 # Hyphenated versions used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
-    module load jedi-$MPI
+    module load jedi-$JEDI_COMPILER
+    module load jedi-$JEDI_MPI
     module list
     set -x
 
@@ -54,6 +54,4 @@ $SUDO make install F90=$FC ESMF_COMM=$ESMF_COMM CONFIG="${compilerD}-${mpiD}" pr
 
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log			   
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log			   

--- a/buildscripts/libs/build_boost.sh
+++ b/buildscripts/libs/build_boost.sh
@@ -33,16 +33,16 @@ fi
 ########################################################################
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 debug="--debug-configuration"
 
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
-    [[ -z $mpi ]] || module load jedi-$MPI
+    module load jedi-$JEDI_COMPILER
+    [[ -z $mpi ]] || module load jedi-$JEDI_MPI
     module list
     set -x
     prefix="${PREFIX:-"$HOME/opt"}/$compiler/$mpi/$name/$version"
@@ -99,5 +99,3 @@ rm -f $HOME/user-config.jam
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi
 $MODULES && update_modules $modpath $name $version \
          || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0

--- a/buildscripts/libs/build_bufrlib.sh
+++ b/buildscripts/libs/build_bufrlib.sh
@@ -36,6 +36,7 @@ cd ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}
 [[ -d $software ]] || git clone https://github.com/JCSDA/$software.git
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+git fetch
 git checkout $version
 
 VERBOSE="$MAKE_VERBOSE" $SUDO ./tools/build.sh $prefix -DBUILD_SHARED_LIBS=1

--- a/buildscripts/libs/build_bufrlib.sh
+++ b/buildscripts/libs/build_bufrlib.sh
@@ -1,18 +1,17 @@
 #!/bin/bash
 
 set -ex
-
 name="bufrlib"
 version=$1
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
 
 # manage package dependencies here
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
+    module load jedi-$JEDI_COMPILER
     module list
     set -x
 
@@ -39,10 +38,8 @@ cd ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 git checkout $version
 
-$SUDO ./tools/build.sh $prefix -DBUILD_SHARED_LIBS=1
+VERBOSE="$MAKE_VERBOSE" $SUDO ./tools/build.sh $prefix -DBUILD_SHARED_LIBS=1
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_cgal.sh
+++ b/buildscripts/libs/build_cgal.sh
@@ -29,7 +29,7 @@ version=$1
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
+    module load jedi-$JEDI_COMPILER
     module load boost-headers
     module load zlib
     module list

--- a/buildscripts/libs/build_cgal.sh
+++ b/buildscripts/libs/build_cgal.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+#
+# CGAL Library used by Atlas
+# https://www.cgal.org
+#
+# WARNING: 
+#   Dependencies in clud the gnu gmp and mpfr libraries
+#   Also, if you are using gnu compilers prior to 9.0, then
+#   you also need to install the boost.thread libraries.
+#   These are often availble from package managers such as
+#   apt, yum, or brew.  For example, for debian systems:
+#
+#   sudo apt-get update
+#   sudo apt-get install libgmp-dev
+#   sudo apt-get install libmpfr-dev
+#   sudo apt-get install libboost-thread-dev
+#
+#
+
+set -ex
+
+name="cgal"
+version=$1
+
+[[ $USE_SUDO =~ [yYtT] ]] && export SUDO="sudo" || unset SUDO
+
+# this is only needed if MAKE_CHECK is enabled
+if $MODULES; then
+    set +x
+    source $MODULESHOME/init/bash
+    module load jedi-$COMPILER
+    module load boost-headers
+    module load zlib
+    module list
+    set -x
+
+    prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
+    if [[ -d $prefix ]]; then
+	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+            || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+    fi
+
+else
+    prefix=${CGAL_ROOT:-"/usr/local"}
+fi    
+
+cd $JEDI_STACK_ROOT/${PKGDIR:-"pkg"}
+
+software="CGAL-"$version
+url="https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-$version/$software-library.tar.xz"
+[[ -d $software ]] || ( $WGET $url; tar -xf $software-library.tar.xz )
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+
+cmake . -DCMAKE_INSTALL_PREFIX=$prefix
+$SUDO make install
+
+# generate modulefile from template
+$MODULES && update_modules core $name $version \
+	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
+
+exit 0

--- a/buildscripts/libs/build_cmake.sh
+++ b/buildscripts/libs/build_cmake.sh
@@ -11,7 +11,7 @@ name="cmake"
 version=$1
 
 if $MODULES; then
-    module load jedi-$COMPILER
+    module load jedi-$JEDI_COMPILER
     module list
 
     prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
@@ -40,6 +40,4 @@ $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules core $name $version \
- 	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_ecbuild.sh
+++ b/buildscripts/libs/build_ecbuild.sh
@@ -9,15 +9,19 @@ dash_version=$(echo -n $version | sed -e "s@/@-@g")
 
 if $MODULES; then
 
-    module try-load cmake
+  set +x
+  source $MODULESHOME/init/bash
+  module try-load cmake
+  module list
+  set -x
 
-    prefix="${PREFIX:-"/opt/modules"}/core/$name/$source-$dash_version"
-    if [[ -d $prefix ]]; then
-	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-            || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
-    fi
+  prefix="${PREFIX:-"/opt/modules"}/core/$name/$source-$dash_version"
+  if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
+                               || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+  fi
 else
-    prefix=${ECBUILD_ROOT:-"/usr/local"}
+  prefix=${ECBUILD_ROOT:-"/usr/local"}
 fi
 
 software=ecbuild
@@ -35,4 +39,4 @@ VERBOSE="$MAKE_VERBOSE" $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules core $name $source-$dash_version \
-         || echo $name $source-$dash_version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log			   
+         || echo $name $source-$dash_version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_ecbuild.sh
+++ b/buildscripts/libs/build_ecbuild.sh
@@ -30,6 +30,7 @@ cd ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}
 [[ -d $software ]] || git clone https://github.com/$source/$software.git
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+git fetch
 git checkout $version
 [[ -d build ]] && $SUDO rm -rf build
 mkdir -p build && cd build

--- a/buildscripts/libs/build_ecbuild.sh
+++ b/buildscripts/libs/build_ecbuild.sh
@@ -31,10 +31,8 @@ git checkout $version
 mkdir -p build && cd build
 
 cmake -DCMAKE_INSTALL_PREFIX=$prefix ..
-$SUDO make install
+VERBOSE="$MAKE_VERBOSE" $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules core $name $source-$dash_version \
-	 || echo $name $source-$dash_version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log			   
-
-exit 0
+         || echo $name $source-$dash_version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log			   

--- a/buildscripts/libs/build_eccodes.sh
+++ b/buildscripts/libs/build_eccodes.sh
@@ -6,15 +6,15 @@ name="eccodes"
 version=$1
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
 
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
-    module load jedi-$MPI
-    module load cmake
-    module load szip
+    module load jedi-$JEDI_COMPILER
+    module load jedi-$JEDI_MPI 
+    module try-load cmake
+    module try-load szip
     module load hdf5
     module load netcdf
     module list
@@ -22,7 +22,7 @@ if $MODULES; then
 
     prefix="${PREFIX:-"$HOME/opt"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
-	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
                                    || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
 
@@ -51,12 +51,10 @@ mkdir -p build && cd build
 
 cmake -DCMAKE_INSTALL_PREFIX=$prefix -DENABLE_NETCDF=ON -DENABLE_FORTRAN=ON ..
 
-make -j${NTHREADS:-4}
+VERBOSE="$MAKE_VERBOSE" make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && ctest
-$SUDO make install
+VERBOSE="$MAKE_VERBOSE" $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_eckit.sh
+++ b/buildscripts/libs/build_eckit.sh
@@ -47,6 +47,7 @@ cd ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}
 [[ -d $software ]] || git clone https://github.com/$source/$software.git
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+git fetch
 git checkout $version
 sed -i -e 's/project( eckit CXX/project( eckit CXX Fortran/' CMakeLists.txt
 [[ -d build ]] && rm -rf build

--- a/buildscripts/libs/build_eckit.sh
+++ b/buildscripts/libs/build_eckit.sh
@@ -8,18 +8,19 @@ source=$1
 version=$2
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 [[ $MAKE_VERBOSE =~ [yYtT] ]] && verb="VERBOSE=1" || unset verb
 
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
-    module load jedi-$MPI
+    module load jedi-$JEDI_COMPILER
+    module load jedi-$JEDI_MPI 
     module try-load cmake
-    module load zlib udunits
+    module try-load zlib
+    module try-load udunits
     module load netcdf
     module load boost-headers eigen
     module load ecbuild
@@ -28,7 +29,7 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$source-$version"
     if [[ -d $prefix ]]; then
-	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
                                    || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
 
@@ -57,6 +58,4 @@ $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules mpi $name $source-$version \
-	 || echo $name $source-$version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $source-$version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_eigen.sh
+++ b/buildscripts/libs/build_eigen.sh
@@ -11,20 +11,20 @@ version=$1
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
+    module load jedi-$JEDI_COMPILER
     module load boost-headers
     module list
     set -x
 
     prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
     if [[ -d $prefix ]]; then
-	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-            || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
 
 else
     prefix=${EIGEN_ROOT:-"/usr/local"}
-fi    
+fi
 
 cd $JEDI_STACK_ROOT/${PKGDIR:-"pkg"}
 
@@ -42,6 +42,6 @@ $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules core $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
 
 exit 0

--- a/buildscripts/libs/build_esmf.sh
+++ b/buildscripts/libs/build_esmf.sh
@@ -8,19 +8,19 @@ version=$1
 software=${name}_$version
 
 # Hyphenated versions used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 if $MODULES; then
   set +x
   source $MODULESHOME/init/bash
-  module load jedi-$COMPILER
-  module load szip
-  [[ -z $mpi ]] || module load jedi-$MPI
+  module load jedi-$JEDI_COMPILER
+  module try-load szip
+  [[ -z $mpi ]] || module load jedi-$JEDI_MPI 
   module load hdf5
   [[ -z $mpi ]] || module load pnetcdf
   module load netcdf
-  module load udunits
+  module try-load udunits
   module list
   set -x
 
@@ -103,5 +103,3 @@ $SUDO make install
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi
 $MODULES && update_modules $modpath $name $version \
          || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0

--- a/buildscripts/libs/build_fckit.sh
+++ b/buildscripts/libs/build_fckit.sh
@@ -46,6 +46,7 @@ cd ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}
 [[ -d $software ]] || git clone https://github.com/$source/$software.git
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+git fetch
 git checkout $version
 [[ -d build ]] && $SUDO rm -rf build
 mkdir -p build && cd build

--- a/buildscripts/libs/build_fftw.sh
+++ b/buildscripts/libs/build_fftw.sh
@@ -8,13 +8,13 @@ version=$1
 software=$name-$version
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 set +x
 source $MODULESHOME/init/bash
-module load jedi-$COMPILER
-[[ -z $mpi ]] || module load jedi-$MPI
+module load jedi-$JEDI_COMPILER
+[[ -z $mpi ]] || module load jedi-$JEDI_MPI 
 module list
 set -x
 
@@ -59,5 +59,3 @@ $SUDO make install
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi
 $MODULES && update_modules $modpath $name $version \
          || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0

--- a/buildscripts/libs/build_gnu.sh
+++ b/buildscripts/libs/build_gnu.sh
@@ -35,5 +35,3 @@ $SUDO make install-strip
 # generate modulefile from template
 $MODULES && update_modules core $name $version \
          || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0

--- a/buildscripts/libs/build_jasper.sh
+++ b/buildscripts/libs/build_jasper.sh
@@ -6,11 +6,11 @@ name="jasper"
 version=$1
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
 
 set +x
 source $MODULESHOME/init/bash
-module load jedi-$COMPILER
+module load jedi-$JEDI_COMPILER
 module list
 set -x
 
@@ -67,5 +67,3 @@ $SUDO make install
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \
          || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0

--- a/buildscripts/libs/build_lapack.sh
+++ b/buildscripts/libs/build_lapack.sh
@@ -6,13 +6,13 @@ name="lapack"
 version=$1
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
 
 # manage package dependencies here
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
+    module load jedi-$JEDI_COMPILER
     module list
     set -x
 
@@ -48,12 +48,10 @@ mkdir -p build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR:PATH=$prefix/lib \
       -DCMAKE_Fortran_COMPILER=$SERIAL_FC -DCMAKE_Fortran_FLAGS=$FCFLAGS ..
 
-make -j${NTHREADS:-4} 
+VERBOSE="$MAKE_VERBOSE" make -j${NTHREADS:-4} 
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
-$SUDO make install
+VERBOSE="$MAKE_VERBOSE" $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_mpi.sh
+++ b/buildscripts/libs/build_mpi.sh
@@ -15,11 +15,11 @@ case "$name" in
 esac
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
 
 set +x
 source $MODULESHOME/init/bash
-module load jedi-$COMPILER
+module load jedi-$JEDI_COMPILER
 module list
 set -x
 
@@ -60,5 +60,3 @@ $SUDO make install
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \
          || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0

--- a/buildscripts/libs/build_nccmp.sh
+++ b/buildscripts/libs/build_nccmp.sh
@@ -8,15 +8,15 @@ version=$1
 software=$name-$version
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
-    [[ -z $mpi ]] || module load jedi-$MPI
-    module load szip
+    module load jedi-$JEDI_COMPILER
+    [[ -z $mpi ]] || module load jedi-$JEDI_MPI 
+    module try-load szip
     module load hdf5
     module load netcdf
     module list
@@ -66,6 +66,4 @@ $SUDO make install
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi
 $MODULES && update_modules $modpath $name $version \
-   || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_nccmp.sh
+++ b/buildscripts/libs/build_nccmp.sh
@@ -15,7 +15,7 @@ if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
     module load jedi-$JEDI_COMPILER
-    [[ -z $mpi ]] || module load jedi-$JEDI_MPI 
+    [[ -z $mpi ]] || module load jedi-$JEDI_MPI
     module try-load szip
     module load hdf5
     module load netcdf
@@ -44,7 +44,7 @@ fi
 export CFLAGS="-fPIC"
 export LDFLAGS="-L$NETCDF_ROOT/lib -L$HDF5_ROOT/lib -L$SZIP_ROOT/lib"
 
-url="https://sourceforge.net/projects/nccmp/files/${software}.tar.gz"
+url="https://gitlab.com/remikz/nccmp/-/archive/$version/${software}.tar.gz"
 
 cd ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}
 

--- a/buildscripts/libs/build_nceplibs.sh
+++ b/buildscripts/libs/build_nceplibs.sh
@@ -10,19 +10,19 @@ name="nceplibs"
 version=$1
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
 
 # manage package dependencies here
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
+    module load jedi-$JEDI_COMPILER
     module list
     set -x
-    
+
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
-	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
                                    || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
 
@@ -49,6 +49,4 @@ $SUDO mv include $prefix
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_nco.sh
+++ b/buildscripts/libs/build_nco.sh
@@ -6,18 +6,18 @@ name="nco"
 version=$1
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 if $MODULES; then
   set +x
   source $MODULESHOME/init/bash
-  module load jedi-$COMPILER
-  [[ -z $mpi ]] || module load jedi-$MPI
-  module load szip
+  module load jedi-$JEDI_COMPILER
+  [[ -z $mpi ]] || module load jedi-$JEDI_MPI 
+  module try-load szip
   module load hdf5
   module load netcdf
-  module load udunits
+  module try-load udunits
   module list
   set -x
 
@@ -27,7 +27,6 @@ if $MODULES; then
     [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
                                || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
   fi
-
 else
     prefix=${NCO_ROOT:-"/usr/local"}
 fi
@@ -72,5 +71,3 @@ $SUDO make install
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi
 $MODULES && update_modules $modpath $name $version \
          || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0

--- a/buildscripts/libs/build_netcdf.sh
+++ b/buildscripts/libs/build_netcdf.sh
@@ -8,15 +8,15 @@ f_version=$2
 cxx_version=$3
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
-    [[ -z $mpi ]] || module load jedi-$MPI
-    module load szip
+    module load jedi-$JEDI_COMPILER
+    [[ -z $mpi ]] || module load jedi-$JEDI_MPI 
+    module try-load szip
     module load hdf5
     [[ -z $mpi ]] || module load pnetcdf
     module list
@@ -97,7 +97,7 @@ mkdir -p build && cd build
 [[ -z $mpi ]] || extra_conf="--enable-pnetcdf --enable-parallel-tests"
 ../configure --prefix=$prefix --enable-netcdf-4 $extra_conf
 
-make -j${NTHREADS:-4}
+VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 $SUDO make install
 
@@ -131,7 +131,8 @@ mkdir -p build && cd build
 
 ../configure --prefix=$prefix --enable-netcdf-4 $extra_conf
 
-make -j${NTHREADS:-4}
+#VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
+VERBOSE=$MAKE_VERBOSE make -j1 #NetCDF-Fortran-4.5.2 & intel/20 have a linker bug if built with j>1
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 $SUDO make install
 
@@ -154,10 +155,8 @@ mkdir -p build && cd build
 
 ../configure --prefix=$prefix
 
-make -j${NTHREADS:-4}
+VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 $SUDO make install
 
 $MODULES || echo $software >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0

--- a/buildscripts/libs/build_odb.sh
+++ b/buildscripts/libs/build_odb.sh
@@ -6,33 +6,32 @@ name="odb-api"
 version=$1
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 [[ $MAKE_VERBOSE =~ [yYtT] ]] && verb="VERBOSE=1" || unset verb
 
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
-    module load jedi-$MPI
-    module load ecbuild
+    module load jedi-$JEDI_COMPILER
+    module load jedi-$JEDI_MPI 
+    module try-load ecbuild
     module load netcdf
-    module load eckit
+    module try-load eckit
     
     module list
     set -x
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
     if [[ -d $prefix ]]; then
-	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
                                    || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
-    
 else
     prefix=${ODB_ROOT:-"/usr/local"}
 fi
-    
+
 export FC=$MPI_FC
 export CC=$MPI_CC
 export CXX=$MPI_CXX
@@ -65,6 +64,4 @@ $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log			   
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log			   

--- a/buildscripts/libs/build_odc.sh
+++ b/buildscripts/libs/build_odc.sh
@@ -45,6 +45,7 @@ cd ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}
 [[ -d $software ]] || git clone https://github.com/$source/$software.git
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+git fetch
 git checkout $version
 [[ -d build ]] && $SUDO rm -rf build
 mkdir -p build && cd build

--- a/buildscripts/libs/build_odc.sh
+++ b/buildscripts/libs/build_odc.sh
@@ -8,8 +8,8 @@ source=$1
 version=$2
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 [[ $USE_SUDO =~ [yYtT] ]] && export SUDO="sudo" || unset SUDO
 [[ $MAKE_VERBOSE =~ [yYtT] ]] && verb="VERBOSE=1" || unset verb
@@ -17,25 +17,23 @@ mpi=$(echo $MPI | sed 's/\//-/g')
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
-    module load jedi-$MPI
-    module load ecbuild
+    module load jedi-$JEDI_COMPILER
+    module load jedi-$JEDI_MPI 
+    module try-load ecbuild
     module load netcdf
-    module load eckit
+    module try-load eckit
     module list
     set -x
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$source-$version"
     if [[ -d $prefix ]]; then
-	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
                                    || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
-
 else
     prefix=${ODC_ROOT:-"/usr/local"}
 fi
 
-    
 export FC=$MPI_FC
 export CC=$MPI_CC
 export CXX=$MPI_CXX
@@ -58,5 +56,3 @@ $SUDO make $verb install
 # generate modulefile from template
 $MODULES && update_modules mpi $name $source-$version \
          || echo $name $source-$version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0

--- a/buildscripts/libs/build_odyssey.sh
+++ b/buildscripts/libs/build_odyssey.sh
@@ -44,6 +44,7 @@ cd ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}
 [[ -d $software ]] || git clone https://github.com/$source/$software.git
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+git fetch
 git checkout $version
 [[ -d build ]] && $SUDO rm -rf build
 mkdir -p build && cd build

--- a/buildscripts/libs/build_odyssey.sh
+++ b/buildscripts/libs/build_odyssey.sh
@@ -8,8 +8,8 @@ source=$1
 version=$2
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 [[ $USE_SUDO =~ [yYtT] ]] && export SUDO="sudo" || unset SUDO
 [[ $MAKE_VERBOSE =~ [yYtT] ]] && verb="VERBOSE=1" || unset verb
@@ -17,24 +17,22 @@ mpi=$(echo $MPI | sed 's/\//-/g')
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
-    module load jedi-$MPI
-    module load ecbuild
+    module load jedi-$JEDI_COMPILER
+    module load jedi-$JEDI_MPI 
+    module try-load ecbuild
     module load odc
     module list
     set -x
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$source-$version"
     if [[ -d $prefix ]]; then
-	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
                                    || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
-
 else
     prefix=${ODYSSEY_ROOT:-"/usr/local"}
 fi
 
-    
 export FC=$MPI_FC
 export CC=$MPI_CC
 export CXX=$MPI_CXX
@@ -57,5 +55,3 @@ $SUDO make $verb install
 # generate modulefile from template
 $MODULES && update_modules mpi $name $source-$version \
          || echo $name $source-$version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0

--- a/buildscripts/libs/build_pdtoolkit.sh
+++ b/buildscripts/libs/build_pdtoolkit.sh
@@ -6,20 +6,20 @@ name="pdtoolkit"
 version="3.25.1"
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
 
 # manage package dependencies here
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
+    module load jedi-$JEDI_COMPILER
     module load zlib
     module list
     set -x
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
                                    || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
 
@@ -48,6 +48,4 @@ $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_pio.sh
+++ b/buildscripts/libs/build_pio.sh
@@ -46,6 +46,7 @@ branch=pio$(echo $version | sed -e 's/\./_/g')
 [[ -d $software ]] || git clone https://github.com/NCAR/$software
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+git fetch
 git checkout $branch
 [[ -d build ]] && rm -rf build
 mkdir -p build && cd build

--- a/buildscripts/libs/build_pnetcdf.sh
+++ b/buildscripts/libs/build_pnetcdf.sh
@@ -6,23 +6,22 @@ name="pnetcdf"
 version=$1
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
-    module load jedi-$MPI
+    module load jedi-$JEDI_COMPILER
+    module load jedi-$JEDI_MPI 
     module list
     set -x
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
     if [[ -d $prefix ]]; then
-	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
                                    || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
-    
 else
     prefix=${PNETCDF_ROOT:-"/usr/local"}
 fi
@@ -33,7 +32,7 @@ export CC=$MPI_CC
 export CXX=$MPI_CXX
 
 export F9X=$FC
-export FFLAGS="-fPIC"
+export FFLAGS="-fPIC -w"
 export CFLAGS="-fPIC"
 export CXXFLAGS="-fPIC"
 export FCFLAGS="$FFLAGS"
@@ -50,12 +49,10 @@ mkdir -p build && cd build
 
 ../configure --prefix=$prefix
 
-make -j${NTHREADS:-4}
+VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_pyjedi.sh
+++ b/buildscripts/libs/build_pyjedi.sh
@@ -40,5 +40,3 @@ $SUDO python setup.py install
 
 CC=gcc python3 setup.py build 
 $SUDO python3 setup.py install 
-
-exit 0

--- a/buildscripts/libs/build_szip.sh
+++ b/buildscripts/libs/build_szip.sh
@@ -6,19 +6,19 @@ name="szip"
 version=$1
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
 
 # manage package dependencies here
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
+    module load jedi-$JEDI_COMPILER
     module list
     set -x
-    
+
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
-	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
                                    || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
 
@@ -52,6 +52,4 @@ $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_tau2.sh
+++ b/buildscripts/libs/build_tau2.sh
@@ -6,15 +6,15 @@ name="tau2"
 version="2.28.1"
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
-mpi=$(echo $MPI | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+mpi=$(echo $JEDI_MPI | sed 's/\//-/g')
 
 # manage package dependencies here
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
-    module load jedi-$MPI
+    module load jedi-$JEDI_COMPILER
+    module load jedi-$JEDI_MPI 
     module load pdtoolkit
     module load zlib
     module list
@@ -22,10 +22,9 @@ if $MODULES; then
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
     if [[ -d $prefix ]]; then
-    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
                                    || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
-
 else
     prefix=${TAU_ROOT:-"/usr/local/$name/$version"}
 fi
@@ -59,6 +58,4 @@ $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules mpi $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_tkdiff.sh
+++ b/buildscripts/libs/build_tkdiff.sh
@@ -12,7 +12,7 @@ if $MODULES; then
     prefix="${PREFIX:-"/opt/modules"}/core/$name/$version"
     if [[ -d $prefix ]]; then
         [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix; $SUDO mkdir $prefix ) \
-            || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
 else
     prefix=${TKDIFF_ROOT:-"/usr/local"}
@@ -29,6 +29,4 @@ $SUDO mv $software/tkdiff $prefix/bin
 
 # generate modulefile from template
 $MODULES && update_modules core $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_udunits.sh
+++ b/buildscripts/libs/build_udunits.sh
@@ -6,21 +6,20 @@ name="udunits"
 version=$1
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
 
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
+    module load jedi-$JEDI_COMPILER
     module list
     set -x
 
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
-	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
-            || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
-
 else
     prefix=${UDUNITS_ROOT:-"/usr/local"}
 fi
@@ -50,6 +49,4 @@ $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_xerces.sh
+++ b/buildscripts/libs/build_xerces.sh
@@ -6,22 +6,21 @@ name="xerces"
 version=$1
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
 
 # manage package dependencies here
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
+    module load jedi-$JEDI_COMPILER
     module list
     set -x
-    
+
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
-	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
                                    || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
-
 else
     prefix=${XERCES_ROOT:-"/usr/local"}
 fi
@@ -53,6 +52,4 @@ $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/build_zlib.sh
+++ b/buildscripts/libs/build_zlib.sh
@@ -6,17 +6,17 @@ name="zlib"
 version=$1
 
 # Hyphenated version used for install prefix
-compiler=$(echo $COMPILER | sed 's/\//-/g')
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
 
 if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
-    module load jedi-$COMPILER
+    module load jedi-$JEDI_COMPILER
     module list
     set -x
     prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
     if [[ -d $prefix ]]; then
-	[[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
                                    || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
     fi
 else
@@ -49,6 +49,4 @@ $SUDO make install
 
 # generate modulefile from template
 $MODULES && update_modules compiler $name $version \
-	 || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
-
-exit 0
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/update_modules.sh
+++ b/buildscripts/libs/update_modules.sh
@@ -9,16 +9,17 @@
 # $3 = package version
 
 function update_modules {
+    OPT="${JEDI_OPT:-$OPT}"
     case $1 in
         core     )
             tmpl_file=$JEDI_STACK_ROOT/modulefiles/core/$2/$2.lua
             to_dir=$OPT/modulefiles/core ;;
         compiler )
             tmpl_file=$JEDI_STACK_ROOT/modulefiles/compiler/compilerName/compilerVersion/$2/$2.lua
-            to_dir=$OPT/modulefiles/compiler/$COMPILER ;;
+            to_dir=$OPT/modulefiles/compiler/$JEDI_COMPILER ;;
         mpi      )
             tmpl_file=$JEDI_STACK_ROOT/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/$2/$2.lua
-            to_dir=$OPT/modulefiles/mpi/$COMPILER/$MPI ;;
+            to_dir=$OPT/modulefiles/mpi/$JEDI_COMPILER/$JEDI_MPI ;;
         *) echo "ERROR: INVALID MODULE PATH, ABORT!"; exit 1 ;;
     esac
 
@@ -41,50 +42,50 @@ function no_modules {
     # this function defines environment variables that are
     # normally done by the modules.  It's mainly intended
     # for use in generating the containers    
-    
-    compilerName=$(echo $COMPILER | cut -d/ -f1)
-    mpiName=$(echo $MPI | cut -d/ -f1)
+
+    compilerName=$(echo $JEDI_COMPILER | cut -d/ -f1)
+    mpiName=$(echo $JEDI_MPI | cut -d/ -f1)
 
     # these can be specified in the config file
     # so these should be considered defaults
-    
+
     case $compilerName in
-	gnu   )
-	    export SERIAL_CC=${SERIAL_CC:-"gcc"}
-	    export SERIAL_CXX=${SERIAL_CXX:-"g++"}
-	    export SERIAL_FC=${SERIAL_FC:-"gfortran"}
-	    ;;
-	intel )
-	    export SERIAL_CC=${SERIAL_CC:-"icc"}
-	    export SERIAL_CXX=${SERIAL_CXX:-"icpc"}
-	    export SERIAL_FC=${SERIAL_FC:-"ifort"}
-	    ;;
-	clang )
-	    export SERIAL_CC=${SERIAL_CC:-"clang"}
-	    export SERIAL_CXX=${SERIAL_CXX:-"clang++"}
-	    export SERIAL_FC=${SERIAL_FC:-"gfortran"}
-	    ;;
-	*     ) echo "Unknown compiler option = $compilerName, ABORT!"; exit 1 ;;
-    esac    
+      gnu   )
+          export SERIAL_CC=${SERIAL_CC:-"gcc"}
+          export SERIAL_CXX=${SERIAL_CXX:-"g++"}
+          export SERIAL_FC=${SERIAL_FC:-"gfortran"}
+          ;;
+      intel )
+          export SERIAL_CC=${SERIAL_CC:-"icc"}
+          export SERIAL_CXX=${SERIAL_CXX:-"icpc"}
+          export SERIAL_FC=${SERIAL_FC:-"ifort"}
+          ;;
+      clang )
+          export SERIAL_CC=${SERIAL_CC:-"clang"}
+          export SERIAL_CXX=${SERIAL_CXX:-"clang++"}
+          export SERIAL_FC=${SERIAL_FC:-"gfortran"}
+          ;;
+      *     ) echo "Unknown compiler option = $compilerName, ABORT!"; exit 1 ;;
+    esac
 
     case $mpiName in
-	openmpi)
-	    export MPI_CC=${MPI_CC:-"mpicc"}
-	    export MPI_CXX=${MPI_CXX:-"mpicxx"}
-	    export MPI_FC=${MPI_FC:-"mpifort"}
-	    ;;
-	mpich  )
-	    export MPI_CC=${MPI_CC:-"mpicc"}
-	    export MPI_CXX=${MPI_CXX:-"mpicxx"}
-	    export MPI_FC=${MPI_FC:-"mpifort"}
-	    ;;
-	impi   )
-	    export MPI_CC=${MPI_CC:-"mpiicc"}
-	    export MPI_CXX=${MPI_CXX:-"mpiicpc"}
-	    export MPI_FC=${MPI_FC:-"mpiifort"}
-	    ;;
-	*     ) echo "Unknown MPI option = $MPIName, ABORT!"; exit 1 ;;
-    esac    
+      openmpi)
+          export MPI_CC=${MPI_CC:-"mpicc"}
+          export MPI_CXX=${MPI_CXX:-"mpicxx"}
+          export MPI_FC=${MPI_FC:-"mpifort"}
+          ;;
+      mpich  )
+          export MPI_CC=${MPI_CC:-"mpicc"}
+          export MPI_CXX=${MPI_CXX:-"mpicxx"}
+          export MPI_FC=${MPI_FC:-"mpifort"}
+          ;;
+      impi   )
+          export MPI_CC=${MPI_CC:-"mpiicc"}
+          export MPI_CXX=${MPI_CXX:-"mpiicpc"}
+          export MPI_FC=${MPI_FC:-"mpiifort"}
+          ;;
+      *     ) echo "Unknown MPI option = $MPIName, ABORT!"; exit 1 ;;
+    esac
 
     config_file="${JEDI_STACK_ROOT}/buildscripts/config/config_${1:-"container"}.sh"
 
@@ -95,10 +96,26 @@ function no_modules {
             pkg=$(echo $line | cut -d= -f1 | cut -d_ -f3)
             eval export ${pkg}_ROOT="/usr/local"
         fi
-    done < $config_file    
+    done < $config_file
     set -x
-    
+}
+
+function build_lib() {
+    # Args: BUILD_SWITCH_VAR, build_script_name, version, [extra build script args]
+    set +x
+    var="STACK_BUILD_$1"
+    if [[ ${!var} =~ [yYtT] ]]; then
+        ${JEDI_BUILDSCRIPTS_DIR}/libs/build_$2.sh "${@:3}" 2>&1 | tee "$logdir/$2.log"
+        ret=${PIPESTATUS[0]}
+        if [[ $ret > 0 ]]; then 
+            echo "BUILD FAIL!  Lib: $2-$3 Error:$ret"
+            [[ ${STACK_EXIT_ON_FAIL} =~ [yYtT] ]] && exit $ret
+        fi
+        echo "BUILD SUCCESS! Lib: $2-$3"
+    fi
+    set -x
 }
 
 export -f update_modules
-export -f no_modules    
+export -f no_modules
+export -f build_lib

--- a/modulefiles/apps/gentoo/jedi/intel-impi/20.0.lua
+++ b/modulefiles/apps/gentoo/jedi/intel-impi/20.0.lua
@@ -1,0 +1,23 @@
+help([[
+JEDI environment with intel compilers, intel mpi, and intel mkl. Release 2020.0
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+conflict(pkgName)
+
+load("jedi-intel/20.0")
+load("jedi-impi/20.0")
+
+load("hdf5")
+load("pnetcdf")
+load("netcdf")
+load("pio")
+load("bufrlib")
+
+whatis("Name: ".. pkgName)
+whatis("Version: ".. pkgVersion)
+whatis("Category: Application")
+whatis("Description: JEDI environment with intel compilers, intel mpi, and intel mkl. Release 2020.0")

--- a/modulefiles/apps/jedi/intel-impi.lua
+++ b/modulefiles/apps/jedi/intel-impi.lua
@@ -9,7 +9,7 @@ local pkgNameVer = myModuleFullName()
 conflict(pkgName)
 
 load("jedi-intel/17.0.1")
-load("szip/2.1.1")
+try_load("szip/2.1.1")
 load("jedi-impi/17.0.1")
 
 load("hdf5/1.10.5")

--- a/modulefiles/compiler/compilerName/compilerVersion/bufrlib/bufrlib.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/bufrlib/bufrlib.lua
@@ -10,7 +10,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/eccodes/eccodes.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/eccodes/eccodes.lua
@@ -16,7 +16,7 @@ always_load("netcdf")
 prereq("hdf5")
 prereq("netcdf")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/esmf/esmf.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/esmf/esmf.lua
@@ -16,7 +16,7 @@ always_load("netcdf")
 prereq("hdf5")
 prereq("netcdf")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/fftw/fftw.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/fftw/fftw.lua
@@ -11,7 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/hdf5/hdf5.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/hdf5/hdf5.lua
@@ -11,10 +11,9 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("szip")
-prereq("szip")
+try_load("szip")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/impi/impi.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/impi/impi.lua
@@ -22,7 +22,7 @@ prereq("intel/17.0.1")
 
 try_load("szip")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 local base = "/opt/intel17/compilers_and_libraries_2017.1.132"
 
 setenv("I_MPI_ROOT", pathJoin(base,"linux/mpi"))

--- a/modulefiles/compiler/compilerName/compilerVersion/jasper/jasper.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/jasper/jasper.lua
@@ -11,7 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/jedi-impi/jedi-impi.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/jedi-impi/jedi-impi.lua
@@ -9,9 +9,6 @@ local hierA        = hierarchyA(pkgNameVer,1)
 local compNameVer  = hierA[1]
 local compNameVerD = compNameVer:gsub("/","-")
 
---io.stderr:write("compNameVer: ",compNameVer,"\n")
---io.stderr:write("compNameVerD: ",compNameVerD,"\n")
-
 conflict(pkgName)
 conflict("jedi-openmpi","jedi-mpich")
 
@@ -19,7 +16,7 @@ local mpi = pathJoin("impi",pkgVersion)
 load(mpi)
 prereq(mpi)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,"impi",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/jedi-mpich/jedi-mpich.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/jedi-mpich/jedi-mpich.lua
@@ -9,9 +9,6 @@ local hierA        = hierarchyA(pkgNameVer,1)
 local compNameVer  = hierA[1]
 local compNameVerD = compNameVer:gsub("/","-")
 
---io.stderr:write("compNameVer: ",compNameVer,"\n")
---io.stderr:write("compNameVerD: ",compNameVerD,"\n")
-
 conflict(pkgName)
 conflict("jedi-openmpi","jedi-impi")
 
@@ -19,7 +16,7 @@ local mpi = pathJoin("mpich",pkgVersion)
 load(mpi)
 prereq(mpi)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,"mpich",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/jedi-mpt/jedi-mpt.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/jedi-mpt/jedi-mpt.lua
@@ -19,7 +19,7 @@ local mpi = pathJoin("mpt",pkgVersion)
 load(mpi)
 prereq(mpi)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,"mpt",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/jedi-openmpi/jedi-openmpi.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/jedi-openmpi/jedi-openmpi.lua
@@ -16,9 +16,12 @@ local mpi = pathJoin("openmpi",pkgVersion)
 load(mpi)
 prereq(mpi)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,"jedi-openmpi",pkgVersion)
+prepend_path("MODULEPATH", mpath)
+
+local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,"openmpi",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 
 setenv("MPI_FC",  "mpifort")

--- a/modulefiles/compiler/compilerName/compilerVersion/lapack/lapack.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/lapack/lapack.lua
@@ -11,7 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/mpich/mpich.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/mpich/mpich.lua
@@ -17,10 +17,9 @@ family("mpi")
 conflict(pkgName)
 conflict("openmpi","impi")
 
-always_load("szip")
-prereq("szip")
+try_load("szip")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 
 prepend_path("PATH", pathJoin(base,"bin"))
@@ -30,6 +29,12 @@ prepend_path("CPATH", pathJoin(base,"include"))
 prepend_path("MANPATH", pathJoin(base,"share","man"))
 
 setenv("MPI_ROOT",base)
+
+-- Enable FindMPI.cmake to automatically find and configure mpich
+setenv("MPI_HOME", base)
+setenv("MPI_Fortran_COMPILER", pathJoin(base,"bin/mpifort"))
+setenv("MPI_C_COMPILER", pathJoin(base,"bin/mpicc"))
+setenv("MPI_CXX_COMPILER", pathJoin(base,"bin/mpicxx"))
 
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)

--- a/modulefiles/compiler/compilerName/compilerVersion/nccmp/nccmp.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/nccmp/nccmp.lua
@@ -14,7 +14,7 @@ conflict(pkgName)
 always_load("netcdf")
 prereq("netcdf")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/nceplibs/nceplibs.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/nceplibs/nceplibs.lua
@@ -11,7 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/nco/nco.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/nco/nco.lua
@@ -14,7 +14,7 @@ conflict(pkgName)
 always_load("netcdf")
 prereq("netcdf")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/netcdf/netcdf.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/netcdf/netcdf.lua
@@ -14,7 +14,7 @@ conflict(pkgName)
 always_load("hdf5")
 prereq("hdf5")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 
@@ -24,11 +24,11 @@ prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,"lib"))
 prepend_path("CPATH", pathJoin(base,"include"))
 prepend_path("MANPATH", pathJoin(base,"share","man"))
 
-setenv("NETCDF", base)
-setenv("NETCDF_ROOT", base)
-setenv("NETCDF_INCLUDES", pathJoin(base,"include"))
-setenv("NETCDF_LIBRARIES", pathJoin(base,"lib"))
-setenv("NETCDF_VERSION", pkgVersion)
+setenv("NetCDF", base)
+setenv("NetCDF_ROOT", base)
+setenv("NetCDF_INCLUDES", pathJoin(base,"include"))
+setenv("NetCDF_LIBRARIES", pathJoin(base,"lib"))
+setenv("NetCDF_VERSION", pkgVersion)
 
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)

--- a/modulefiles/compiler/compilerName/compilerVersion/netcdf/netcdf.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/netcdf/netcdf.lua
@@ -30,6 +30,12 @@ setenv("NetCDF_INCLUDES", pathJoin(base,"include"))
 setenv("NetCDF_LIBRARIES", pathJoin(base,"lib"))
 setenv("NetCDF_VERSION", pkgVersion)
 
+setenv("NETCDF", base)
+setenv("NETCDF_ROOT", base)
+setenv("NETCDF_INCLUDES", pathJoin(base,"include"))
+setenv("NETCDF_LIBRARIES", pathJoin(base,"lib"))
+setenv("NETCDF_VERSION", pkgVersion)
+
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)
 whatis("Category: library")

--- a/modulefiles/compiler/compilerName/compilerVersion/openmpi/openmpi.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/openmpi/openmpi.lua
@@ -14,10 +14,9 @@ family("mpi")
 conflict(pkgName)
 conflict("mpich","impi")
 
-always_load("szip")
-prereq("szip")
+try_load("szip")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,pkgName,pkgVersion)
 prepend_path("MODULEPATH", mpath)
@@ -31,6 +30,12 @@ prepend_path("CPATH", pathJoin(base,"include"))
 prepend_path("MANPATH", pathJoin(base,"share","man"))
 
 setenv("MPI_ROOT", base)
+
+-- Enable FindMPI.cmake to automatically find and configure OpenMPI
+setenv("MPI_HOME", base)
+setenv("MPI_Fortran_COMPILER", pathJoin(base,"bin/mpifort"))
+setenv("MPI_C_COMPILER", pathJoin(base,"bin/mpicc"))
+setenv("MPI_CXX_COMPILER", pathJoin(base,"bin/mpicxx"))
 
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)

--- a/modulefiles/compiler/compilerName/compilerVersion/pdtoolkit/pdtoolkit.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/pdtoolkit/pdtoolkit.lua
@@ -11,7 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/szip/szip.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/szip/szip.lua
@@ -11,7 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/udunits/udunits.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/udunits/udunits.lua
@@ -11,7 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/xerces/xerces.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/xerces/xerces.lua
@@ -11,7 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/compiler/compilerName/compilerVersion/zlib/zlib.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/zlib/zlib.lua
@@ -11,7 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/core/anaconda/anaconda2.lua
+++ b/modulefiles/core/anaconda/anaconda2.lua
@@ -7,7 +7,7 @@ local pkgNameVer = myModuleFullName()
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,pkgVersion)
 

--- a/modulefiles/core/anaconda/anaconda3.lua
+++ b/modulefiles/core/anaconda/anaconda3.lua
@@ -7,7 +7,7 @@ local pkgNameVer = myModuleFullName()
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,pkgVersion)
 

--- a/modulefiles/core/aws/aws.lua
+++ b/modulefiles/core/aws/aws.lua
@@ -7,7 +7,7 @@ local pkgNameVer = myModuleFullName()
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,pkgName)
 

--- a/modulefiles/core/boost-headers/boost-headers.lua
+++ b/modulefiles/core/boost-headers/boost-headers.lua
@@ -8,7 +8,7 @@ local pkgNameVer = myModuleFullName()
 conflict(pkgName)
 conflict("boost")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,"core","boost",pkgVersion)
 

--- a/modulefiles/core/cgal/cgal.lua
+++ b/modulefiles/core/cgal/cgal.lua
@@ -1,0 +1,29 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+conflict(pkgName)
+
+prereq("boost-headers")
+
+local opt = os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,"core",pkgName,pkgVersion)
+
+prepend_path("CPATH", pathJoin(base,"include"))
+prepend_path("MANPATH", pathJoin(base,"share","man"))
+
+setenv("CGAL_ROOT", base)
+setenv("CGAL_PATH", base)
+setenv("CGAL_DIR", base)
+setenv("CGAL_INCLUDE_DIRS", pathJoin(base,"include"))
+setenv("CGAL_LIBRARIES", pathJoin(base,"lib"))
+setenv("CGAL_VERSION", pkgVersion)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: CGAL library")

--- a/modulefiles/core/cmake/cmake.lua
+++ b/modulefiles/core/cmake/cmake.lua
@@ -7,7 +7,7 @@ local pkgNameVer = myModuleFullName()
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,"core",pkgName,pkgVersion)
 

--- a/modulefiles/core/ecbuild/ecbuild.lua
+++ b/modulefiles/core/ecbuild/ecbuild.lua
@@ -9,7 +9,7 @@ conflict(pkgName)
 
 try_load("cmake")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,"core",pkgName,pkgVersion)
 

--- a/modulefiles/core/eigen/eigen.lua
+++ b/modulefiles/core/eigen/eigen.lua
@@ -9,7 +9,7 @@ conflict(pkgName)
 
 try_load("boost_headers")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,"core",pkgName,pkgVersion)
 

--- a/modulefiles/core/gnu/gnu.lua
+++ b/modulefiles/core/gnu/gnu.lua
@@ -10,7 +10,7 @@ family("compiler")
 conflict(pkgName)
 conflict("intel")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local mpath = pathJoin(opt,"modulefiles/compiler",pkgName,pkgVersion)
 prepend_path("MODULEPATH", mpath)

--- a/modulefiles/core/intel/intel17.lua
+++ b/modulefiles/core/intel/intel17.lua
@@ -10,7 +10,7 @@ family("compiler")
 conflict(pkgName)
 conflict("gnu")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 local mklroot = "/opt/intel17/compilers_and_libraries_2017.1.132/linux/mkl"
 
 prepend_path("PATH","/opt/intel17/compilers_and_libraries_2017.1.132/linux/bin/intel64:/opt/intel17/compilers_and_libraries_2017.1.132/linux/mpi/intel64/bin:/opt/intel17/debugger_2017/gdb/intel64_mic/bin")

--- a/modulefiles/core/jedi-clang/jedi-clang.lua
+++ b/modulefiles/core/jedi-clang/jedi-clang.lua
@@ -14,7 +14,7 @@ local compiler = pathJoin("clang",pkgVersion)
 load(compiler)
 prereq(compiler)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 local mpath = pathJoin(opt,"modulefiles/compiler","clang",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 

--- a/modulefiles/core/jedi-gnu/jedi-gnu.lua
+++ b/modulefiles/core/jedi-gnu/jedi-gnu.lua
@@ -14,9 +14,12 @@ local compiler = pathJoin("gnu",pkgVersion)
 load(compiler)
 prereq(compiler)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
-local mpath = pathJoin(opt,"modulefiles/compiler",pkgName,pkgVersion)
+local mpath = pathJoin(opt,"modulefiles/compiler","gnu",pkgVersion)
+prepend_path("MODULEPATH", mpath)
+
+local mpath = pathJoin(opt,"modulefiles/compiler","jedi-gnu",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 
 setenv("FC",  "gfortran")

--- a/modulefiles/core/jedi-intel/jedi-intel.lua
+++ b/modulefiles/core/jedi-intel/jedi-intel.lua
@@ -15,7 +15,7 @@ load(compiler)
 prereq(compiler)
 try_load("mkl")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 local mpath = pathJoin(opt,"modulefiles/compiler","intel",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 

--- a/modulefiles/core/opengrads/opengrads.lua
+++ b/modulefiles/core/opengrads/opengrads.lua
@@ -7,7 +7,7 @@ local pkgNameVer = myModuleFullName()
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,pkgName,pkgVersion)
 

--- a/modulefiles/core/tapenade/tapenade.lua
+++ b/modulefiles/core/tapenade/tapenade.lua
@@ -7,7 +7,7 @@ local pkgNameVer = myModuleFullName()
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,pkgName,pkgName .. pkgVersion)
 

--- a/modulefiles/core/tkdiff/tkdiff.lua
+++ b/modulefiles/core/tkdiff/tkdiff.lua
@@ -7,7 +7,7 @@ local pkgNameVer = myModuleFullName()
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,"core",pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/baselibs/baselibs.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/baselibs/baselibs.lua
@@ -18,7 +18,7 @@ conflict("netcdf")
 conflict("udunits")
 conflict("esmf")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/boost/boost.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/boost/boost.lua
@@ -13,7 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/eckit/eckit.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/eckit/eckit.lua
@@ -18,7 +18,7 @@ load("boost-headers","eigen")
 
 prereq("netcdf","boost-headers","eigen")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/esmf/esmf.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/esmf/esmf.lua
@@ -13,7 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/fckit/fckit.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/fckit/fckit.lua
@@ -13,11 +13,9 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("eckit")
+try_load("eckit")
 
-prereq("eckit")
-
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/fftw/fftw.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/fftw/fftw.lua
@@ -13,7 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/hdf5/hdf5.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/hdf5/hdf5.lua
@@ -13,7 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nccmp/nccmp.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nccmp/nccmp.lua
@@ -16,7 +16,7 @@ conflict(pkgName)
 always_load("netcdf")
 prereq("netcdf")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nco/nco.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/nco/nco.lua
@@ -13,7 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/netcdf/netcdf.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/netcdf/netcdf.lua
@@ -16,7 +16,7 @@ conflict(pkgName)
 load("hdf5","pnetcdf")
 prereq("hdf5","pnetcdf")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/netcdf/netcdf.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/netcdf/netcdf.lua
@@ -32,6 +32,12 @@ setenv("NETCDF_INCLUDES", pathJoin(base,"include"))
 setenv("NETCDF_LIBRARIES", pathJoin(base,"lib"))
 setenv("NETCDF_VERSION", pkgVersion)
 
+setenv("NetCDF", base)
+setenv("NetCDF_ROOT", base)
+setenv("NetCDF_INCLUDES", pathJoin(base,"include"))
+setenv("NetCDF_LIBRARIES", pathJoin(base,"lib"))
+setenv("NetCDF_VERSION", pkgVersion)
+
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)
 whatis("Category: library")

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/odb-api/odb-api.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/odb-api/odb-api.lua
@@ -13,10 +13,12 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("ecbuild","netcdf","eckit")
-prereq("ecbuild","netcdf","eckit")
+try_load("ecbuild")
+try_load("eckit")
+always_load("netcdf")
+prereq("netcdf")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 
@@ -27,7 +29,7 @@ prepend_path("CPATH", pathJoin(base,"include"))
 prepend_path("MANPATH", pathJoin(base,"share","man"))
 prepend_path("PYTHONPATH", pathJoin(base, "lib/python2.7/site-packages"))
 
-setenv( "ODB_ROOT", base)
+setenv( "odb_ROOT", base)
 setenv( "ODB_API_PATH", base)
 setenv( "ODB_API_VERSION", pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/odc/odc.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/odc/odc.lua
@@ -13,10 +13,12 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-load("ecbuild","netcdf","eckit")
-prereq("ecbuild","netcdf","eckit")
+try_load("ecbuild")
+try_load("eckit")
+always_load("netcdf")
+prereq("netcdf")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/odyssey/odyssey.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/odyssey/odyssey.lua
@@ -16,7 +16,7 @@ conflict(pkgName)
 always_load("odc")
 prereq("odc")
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 local odc_lib = pathJoin(os.getenv("odc_ROOT"), "lib")
 local olib_pattern = pathJoin(base, "lib/python3*/site-packages")

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/pio/pio.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/pio/pio.lua
@@ -13,7 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/pnetcdf/pnetcdf.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/pnetcdf/pnetcdf.lua
@@ -13,7 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/tau2/tau2.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/tau2/tau2.lua
@@ -11,7 +11,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-local opt = os.getenv("OPT") or "/opt/modules"
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
 

--- a/modulefiles/system/gentoo/impi/20.0.lua
+++ b/modulefiles/system/gentoo/impi/20.0.lua
@@ -1,0 +1,87 @@
+family("mpi")
+whatis("Intel mpi and libfabric")
+help([[Intel mpi and libfabric]])
+
+conflict(myModuleName())
+conflict("mpich","openmp")
+
+local posix = require("posix")
+
+local intel_root_path = os.getenv("INTEL_HOME") or pathJoin(os.getenv("HOME"),"intel")
+local intel_release_path = pathJoin(intel_root_path,"compilers_and_libraries_2020.0.166/linux")
+local intel_license_path = pathJoin(intel_root_path,"licenses")
+
+setenv("INTEL_MPI_RELEASE_PATH", intel_release_path)
+prepend_path("INTEL_LICENSE_FILE", intel_license_path)
+
+-- Intel MPI
+local intel_mpi_root = pathJoin(intel_release_path,"mpi")
+local intel_mpi_intel64_path = pathJoin(intel_mpi_root,"intel64")
+local libfabric_bin_path  = pathJoin(intel_mpi_intel64_path,"libfabric/bin")
+local libfabric_lib_path  = pathJoin(intel_mpi_intel64_path,"libfabric/lib")
+local libfabric_prov_path  = pathJoin(intel_mpi_intel64_path,"libfabric/lib/prov")
+local mpi_bin_path  = pathJoin(intel_mpi_intel64_path,"bin")
+local mpi_include_path  = pathJoin(intel_mpi_intel64_path,"include")
+local mpi_man_path = pathJoin(intel_mpi_root,"man")
+local mpi_lib_path  = pathJoin(intel_mpi_intel64_path,"lib")
+local mpi_lib_release_path  = pathJoin(intel_mpi_intel64_path,"lib/release")
+local mpi_lib_debug_path  = pathJoin(intel_mpi_intel64_path,"lib/debug")
+local mpi_lib_release_mt_path  = pathJoin(intel_mpi_intel64_path,"lib/release_mt")
+local mpi_lib_debug_mt_path  = pathJoin(intel_mpi_intel64_path,"lib/debug_mt")
+local mpi_lib_kind = os.getenv("I_MPI_LIBRARY_KIND") or "release"
+
+prepend_path("PATH",libfabric_bin_path)
+prepend_path("LD_LIBRARY_PATH",libfabric_lib_path)
+prepend_path("LD_LIBRARY_PATH",libfabric_prov_path)
+prepend_path("LIBRARY_PATH",libfabric_lib_path)
+
+prepend_path("PATH",mpi_bin_path)
+prepend_path("MANPATH",mpi_man_path)
+prepend_path("CPATH",mpi_include_path)
+
+if mpi_lib_kind == "release" then
+    prepend_path("LD_LIBRARY_PATH",mpi_lib_release_path)
+    prepend_path("LIBRARY_PATH",mpi_lib_release_path)
+    setenv("I_MPI_LIBRARY_KIND", mpi_lib_kind)
+elseif mpi_lib_kind == "debug" then
+    prepend_path("LD_LIBRARY_PATH",mpi_lib_debug_path)
+    prepend_path("LIBRARY_PATH",mpi_lib_debug_path)
+elseif mpi_lib_kind == "release_mt" then
+    prepend_path("LD_LIBRARY_PATH",mpi_lib_release_mt_path)
+    prepend_path("LIBRARY_PATH",mpi_lib_release_mt_path)
+elseif mpi_lib_kind == "debug_mt" then
+    prepend_path("LD_LIBRARY_PATH",mpi_lib_debug_mt_path)
+    prepend_path("LIBRARY_PATH",mpi_lib_debug_mt_path)
+else
+    print("Unknown intel MPI library kind:", mpi_lib_kind)
+    print("Defaulting to using release libs")
+    prepend_path("LD_LIBRARY_PATH",mpi_lib_release_path)
+    prepend_path("LIBRARY_PATH",mpi_lib_release_path)
+    setenv("I_MPI_LIBRARY_KIND", mpi_lib_kind)
+end
+
+-- For intel comonents this should be the root above the intel64 directory
+setenv("I_MPI_ROOT", intel_mpi_root)
+-- setenv("INTEL_MPI_PATH", intel_mpi_intel64_path)
+
+-- For CMake to find the mpiexec and other programs INTEL
+pushenv("MPI_HOME", intel_mpi_intel64_path)
+pushenv("MPIEXEC_EXECUTABLE", pathJoin(mpi_bin_path,"mpiexec"))
+pushenv("MPI_Fortran_COMPILER", pathJoin(mpi_bin_path,"mpiifort"))
+pushenv("MPI_C_COMPILER", pathJoin(mpi_bin_path,"mpiicc"))
+pushenv("MPI_CXX_COMPILER", pathJoin(mpi_bin_path,"mpiicpc"))
+pushenv("MPIFC",pathJoin(mpi_bin_path,"mpiifort"))
+pushenv("MPICC",pathJoin(mpi_bin_path,"mpiicc"))
+pushenv("MPICXX",pathJoin(mpi_bin_path,"mpiicpc"))
+-- For jedi-stack which like to have a '_'
+pushenv("MPI_FC",pathJoin(mpi_bin_path,"mpiifort"))
+pushenv("MPI_CC",pathJoin(mpi_bin_path,"mpiicc"))
+pushenv("MPI_CXX",pathJoin(mpi_bin_path,"mpiicpc"))
+-- For intel-provided mpifort mpicc mpicxx scripts to set default compiler
+pushenv("I_MPI_F77","ifort")
+pushenv("I_MPI_F90","ifort")
+pushenv("I_MPI_FC","ifort")
+pushenv("I_MPI_CC","icc")
+pushenv("I_MPI_CXX","icpc")
+--For ParallelIO CMake to detect MPIMOD_PATH
+pushenv("MPI_Fortran_INCLUDE_PATH",mpi_include_path)

--- a/modulefiles/system/gentoo/intel/20.0.lua
+++ b/modulefiles/system/gentoo/intel/20.0.lua
@@ -1,0 +1,30 @@
+family("compiler")
+whatis("Intel x86_64 compilers")
+help([[Intel x86_64 compilers]])
+
+local posix = require("posix")
+
+local intel_root_path = os.getenv("INTEL_ROOT") or os.getenv("INTEL_HOME") or pathJoin(os.getenv("HOME"),"intel")
+local intel_release_path = pathJoin(intel_root_path,"compilers_and_libraries_2020.0.166/linux")
+local intel_license_path = pathJoin(intel_root_path,"licenses")
+
+setenv("INTEL_COMPILER_RELEASE_PATH", intel_release_path)
+prepend_path("INTEL_LICENSE_FILE", intel_license_path)
+
+-- Compiler
+local intel_compiler_path = intel_release_path
+local compiler_bin_path = pathJoin(intel_compiler_path,"bin/intel64")
+local compiler_lib_path = pathJoin(intel_compiler_path,"compiler/lib/intel64_lin")
+local compiler_inc_path = pathJoin(intel_compiler_path,"compiler/include/intel64")
+local compiler_man_path = pathJoin(intel_compiler_path,"man/common")
+
+prepend_path("PATH",compiler_bin_path)
+prepend_path("CPATH",compiler_inc_path)
+prepend_path("LD_LIBRARY_PATH",compiler_lib_path)
+prepend_path("LIBRARY_PATH",compiler_lib_path)
+prepend_path("MANPATH",compiler_man_path)
+setenv("INTEL_COMPILER_PATH", intel_compiler_path)
+
+pushenv("FC",pathJoin(compiler_bin_path,"ifort"))
+pushenv("CC",pathJoin(compiler_bin_path,"icc"))
+pushenv("CXX",pathJoin(compiler_bin_path,"icpc"))

--- a/modulefiles/system/gentoo/mkl/20.0.lua
+++ b/modulefiles/system/gentoo/mkl/20.0.lua
@@ -1,0 +1,34 @@
+whatis("Intel mkl")
+help([[Intel mkl]])
+
+local posix = require("posix")
+
+local intel_root_path =  os.getenv("INTEL_HOME") or pathJoin(os.getenv("HOME"),"intel")
+local intel_release_path = pathJoin(intel_root_path,"compilers_and_libraries_2020.0.166/linux")
+local intel_license_path = pathJoin(intel_root_path,"licenses")
+
+setenv("INTEL_MKL_RELEASE_PATH", intel_release_path)
+prepend_path("INTEL_LICENSE_FILE", intel_license_path)
+
+-- MKL (32-bit integer indexing [lp64] using 64-bit libraries)
+local intel_mkl_path = pathJoin(intel_release_path,"mkl")
+local mkl_lib_path  = pathJoin(intel_mkl_path,"lib/intel64_lin")
+local mkl_inc_path  = pathJoin(intel_mkl_path,"include")
+local mkl_ilp64_module_path  = pathJoin(intel_mkl_path,"include/intel64/ilp64") -- 64-bit integer interface
+local mkl_lp64_module_path  = pathJoin(intel_mkl_path,"include/intel64/lp64") -- 32-bit integer interface
+local mkl_pkgconfig_path  = pathJoin(intel_mkl_path,"bin/pkgconfig")
+
+prepend_path("LD_LIBRARY_PATH",mkl_lib_path) -- dynamic loader serach paths
+prepend_path("LIBRARY_PATH",mkl_lib_path) -- Compiler -L search dirs
+prepend_path("CPATH",mkl_inc_path) -- Compiler -I search dirs
+
+-- Set Fotran Modules path.  ifort also uses the CPATH. Ther is no ifort specific include variable.
+if os.getenv("MKL_ILP64") and not os.getenv("MKL_ILP64")=="0" then
+    prepend_path("CPATH",mkl_ilp64_module_path)
+else
+    prepend_path("CPATH",mkl_lp64_module_path)
+end
+prepend_path("PKG_CONFIG_PATH",mkl_pkgconfig_path) -- For pkg-config
+setenv("INTEL_MKL_PATH", intel_mkl_path)
+setenv("MKL_PATH", intel_mkl_path) -- ecbuild search name
+setenv("MKL_ROOT", intel_mkl_path) -- cmake findPackage() search name


### PR DESCRIPTION

This adds the CGAL library to the jedi-stack.  CGAL is used by Atlas for Delaunay triangulation when constructing a mesh (inter-node communication infrastructure) for unstructured grids.  For now it will probably be an optional addition to the stack but it may become a required dependency.