### PR TITLE
Feature/update

### DIFF
--- a/buildscripts/build_stack.sh
+++ b/buildscripts/build_stack.sh
@@ -98,7 +98,7 @@ $MODULES && (set +x; module purge; set -x)
 
 # The first argument is the source, either "ecmwf" or "jcsda" (fork)
 [[ $STACK_BUILD_ECBUILD =~ [yYtT] ]] && \
-    libs/build_ecbuild.sh "jcsda" "bugfix/test-lists" 2>&1 | tee "$logdir/ecbuild.log"
+    libs/build_ecbuild.sh "jcsda" "3.1.0.jcsda2" 2>&1 | tee "$logdir/ecbuild.log"
 
 #----------------------
 # These must be rebuilt for each MPI implementation
@@ -118,7 +118,7 @@ $MODULES && (set +x; module purge; set -x)
 
 # The first argument is the source, either "ecmwf" or "jcsda" (fork)
 [[ $STACK_BUILD_ECKIT =~ [yYtT] ]] && \
-    libs/build_eckit.sh "jcsda" "develop" 2>&1 | tee "$logdir/eckit.log"
+    libs/build_eckit.sh "jcsda" "jcsda-1.4.0.jcsda3" 2>&1 | tee "$logdir/eckit.log"
 
 # The first argument is the source, either "ecmwf" or "jcsda" (fork)
 [[ $STACK_BUILD_FCKIT =~ [yYtT] ]] && \

--- a/buildscripts/build_stack.sh
+++ b/buildscripts/build_stack.sh
@@ -98,7 +98,7 @@ $MODULES && (set +x; module purge; set -x)
 
 # The first argument is the source, either "ecmwf" or "jcsda" (fork)
 [[ $STACK_BUILD_ECBUILD =~ [yYtT] ]] && \
-    libs/build_ecbuild.sh "jcsda" "3.1.0.jcsda1" 2>&1 | tee "$logdir/ecbuild.log"
+    libs/build_ecbuild.sh "jcsda" "bugfix/test-lists" 2>&1 | tee "$logdir/ecbuild.log"
 
 #----------------------
 # These must be rebuilt for each MPI implementation
@@ -118,7 +118,7 @@ $MODULES && (set +x; module purge; set -x)
 
 # The first argument is the source, either "ecmwf" or "jcsda" (fork)
 [[ $STACK_BUILD_ECKIT =~ [yYtT] ]] && \
-    libs/build_eckit.sh "jcsda" "1.4.0.jcsda2" 2>&1 | tee "$logdir/eckit.log"
+    libs/build_eckit.sh "jcsda" "develop" 2>&1 | tee "$logdir/eckit.log"
 
 # The first argument is the source, either "ecmwf" or "jcsda" (fork)
 [[ $STACK_BUILD_FCKIT =~ [yYtT] ]] && \
@@ -164,7 +164,7 @@ $MODULES && (set +x; module purge; set -x)
     libs/build_nco.sh "4.7.9" 2>&1 | tee "$logdir/nco.log"
 
 [[ $STACK_BUILD_PIO      =~ [yYtT] ]] && \
-    libs/build_pio.sh "2.4.2" 2>&1 | tee "$logdir/pio.log"
+    libs/build_pio.sh "2.4.4" 2>&1 | tee "$logdir/pio.log"
 
 [[ $STACK_BUILD_FFTW     =~ [yYtT] ]] && \
     libs/build_fftw.sh "3.3.8" 2>&1 | tee "$logdir/fftw.log"

--- a/buildscripts/build_stack.sh
+++ b/buildscripts/build_stack.sh
@@ -118,7 +118,7 @@ $MODULES && (set +x; module purge; set -x)
 
 # The first argument is the source, either "ecmwf" or "jcsda" (fork)
 [[ $STACK_BUILD_ECKIT =~ [yYtT] ]] && \
-    libs/build_eckit.sh "jcsda" "jcsda-1.4.0.jcsda3" 2>&1 | tee "$logdir/eckit.log"
+    libs/build_eckit.sh "jcsda" "1.4.0.jcsda3" 2>&1 | tee "$logdir/eckit.log"
 
 # The first argument is the source, either "ecmwf" or "jcsda" (fork)
 [[ $STACK_BUILD_FCKIT =~ [yYtT] ]] && \

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/eckit/eckit.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/eckit/eckit.lua
@@ -13,8 +13,8 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("netcdf")
-always_load("boost-headers","eigen")
+load("netcdf")
+load("boost-headers","eigen")
 
 prereq("netcdf","boost-headers","eigen")
 

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/netcdf/netcdf.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/netcdf/netcdf.lua
@@ -13,7 +13,6 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("hdf5","pnetcdf")
 prereq("hdf5","pnetcdf")
 
 local opt = os.getenv("OPT") or "/opt/modules"

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/netcdf/netcdf.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/netcdf/netcdf.lua
@@ -13,6 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
+load("hdf5","pnetcdf")
 prereq("hdf5","pnetcdf")
 
 local opt = os.getenv("OPT") or "/opt/modules"

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/odc/odc.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/odc/odc.lua
@@ -13,7 +13,7 @@ local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
-always_load("ecbuild","netcdf","eckit")
+load("ecbuild","netcdf","eckit")
 prereq("ecbuild","netcdf","eckit")
 
 local opt = os.getenv("OPT") or "/opt/modules"


### PR DESCRIPTION
This goes with https://github.com/JCSDA/docker_base/pull/27
Mainly just an update to ecbuild and eckit.  I also changed some module files to ```load``` instead of ```always_load``` because this was causing problems on systems like Cheyenne where there can be a name conflict between jedi-stack modules and native modules and the ```always_load``` sometimes replaces the jedi modules with native, which is not wanted.