### PR TITLE
add Orion configuration and option

### DIFF
--- a/buildscripts/config/config_orion.sh
+++ b/buildscripts/config/config_orion.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Compiler/MPI combination
+export JEDI_COMPILER="intel/2019.5"
+export MPI="openmpi/4.0.2"
+
+# This tells jedi-stack how you want to build the compiler and mpi modules
+# valid options include:
+# native-module: load a pre-existing module (common for HPC systems)
+# native-pkg: use pre-installed executables located in /usr/bin or /usr/local/bin,
+#             as installed by package managers like apt-get or hombrewo.
+#             This is a common option for, e.g., gcc/g++/gfortrant
+# from-source: This is to build from source
+export JEDI_COMPILER_BUILD="native-module"
+export MPI_BUILD="native-module"
+
+# Build options
+export PREFIX=${HOME}/opt
+export USE_SUDO=N
+export PKGDIR=pkg
+export LOGDIR=buildscripts/log
+export OVERWRITE=Y
+export NTHREADS=8
+export   MAKE_CHECK=N
+export MAKE_VERBOSE=N
+export   MAKE_CLEAN=N
+export DOWNLOAD_ONLY=F
+export STACK_EXIT_ON_FAIL=T
+export WGET="wget -nv"
+
+# Minimal JEDI Stack
+export      STACK_BUILD_CMAKE=Y
+export       STACK_BUILD_SZIP=Y
+export    STACK_BUILD_UDUNITS=Y
+export       STACK_BUILD_ZLIB=Y
+export     STACK_BUILD_LAPACK=Y
+export    STACK_BOOST_HEADERS=Y
+export     STACK_BUILD_EIGEN3=Y
+export       STACK_BUILD_HDF5=Y
+export    STACK_BUILD_PNETCDF=Y
+export     STACK_BUILD_NETCDF=Y
+export      STACK_BUILD_NCCMP=Y
+export        STACK_BUILD_NCO=Y
+export    STACK_BUILD_ECBUILD=N
+export      STACK_BUILD_ECKIT=N
+export      STACK_BUILD_FCKIT=N
+export        STACK_BUILD_ODB=N
+export        STACK_BUILD_ODC=N
+export    STACK_BUILD_ODYSSEY=N
+export    STACK_BUILD_BUFRLIB=N
+
+# Optional Additions
+export           STACK_BUILD_PIO=N
+export        STACK_BUILD_PYJEDI=N
+export      STACK_BUILD_NCEPLIBS=N
+export        STACK_BUILD_JASPER=N
+export     STACK_BUILD_ARMADILLO=N
+export        STACK_BUILD_XERCES=N
+export        STACK_BUILD_TKDIFF=N
+export          STACK_BOOST_FULL=N
+export          STACK_BUILD_ESMF=N
+export      STACK_BUILD_BASELIBS=N
+export     STACK_BUILD_PDTOOLKIT=N
+export          STACK_BUILD_TAU2=N
+

--- a/buildscripts/setup_environment.sh
+++ b/buildscripts/setup_environment.sh
@@ -6,8 +6,8 @@
 # file at the top level of this repository.
 #
 # build cmake seperately as part of the module setup
-# 
-# These installations are typically done my means of package installs, 
+#
+# These installations are typically done my means of package installs,
 # Basically, anything that you may want to install with package installers
 # belongs here as opposed to build_stack.sh.
 # However, there are a few packages such as Lmod that you might
@@ -27,13 +27,13 @@
 #
 # Arguments:
 # configuration name (leave blank to print list of supported values)
-# 
+#
 # sample usage
 # ./setup_environment.sh "ubuntu/18.04"
 #
 
 # currently supported options
-supported_options=("ubuntu/18.04","cheyenne")
+supported_options=("ubuntu/18.04","cheyenne","orion")
 
 export JEDI_STACK_ROOT=$PWD/..
 
@@ -50,7 +50,7 @@ case $1 in
 
     # this is currently configured for AWS where standard AMIs come with some basic
     # software pre-installed, such as git, make, wget, curl, etc.
-    
+
     # package install of gnu compilers
     # needed here to install lmod from source
     # the defaults are sufficiently up-to-date (v7.3 as of April, 2018) but we may want
@@ -77,16 +77,16 @@ case $1 in
     sudo apt-get install -y --no-install-recommends graphviz doxygen
 
     # for debugging
-    sudo apt-get install -y --no-install-recommends ddd gdb kdbg valgrind   
+    sudo apt-get install -y --no-install-recommends ddd gdb kdbg valgrind
 
     # python
     sudo apt-get install -y --no-install-recommends python-pip python-dev python-yaml \
-	                 python-numpy python-scipy
+                   python-numpy python-scipy
     sudo apt-get install -y --no-install-recommends python3-pip python3-dev \
-	                 python3-yaml python3-numpy python3-scipy
-    
+                   python3-yaml python3-numpy python3-scipy
+
     # install and deploy lmod from source
-    sudo apt-get install -y tcllib tcl-dev 
+    sudo apt-get install -y tcllib tcl-dev
     prefix=/opt
     libs/build_lmod.sh $prefix
     source $prefix/lmod/lmod/init/profile
@@ -119,6 +119,21 @@ case $1 in
 
     ;;
 #==========================================================================================
+"orion")
+
+    # Orion compiler modules define the environment variable MODULE so in order for
+    # the build scripts to function properly we need to replace it with something else
+    cd ${JEDI_STACK_ROOT}/buildscripts
+    sed -i -e 's/COMPILER/JEDI_COMPILER/g' setup_modules.sh build_stack.sh
+    cd libs
+    sed -i -e 's/COMPILER/JEDI_COMPILER/g' *.sh
+
+    export OPT="$HOME/opt"
+    echo "export OPT=$OPT" >> $HOME/.bashrc
+    echo "module use $OPT/modulefiles/core" >> $HOME/.bashrc
+
+    ;;
+#==========================================================================================
 *)
     set +x
     echo "supported options:"
@@ -126,5 +141,5 @@ case $1 in
     set -x
     ;;
 esac
-    
+
 exit 0

--- a/buildscripts/setup_environment.sh
+++ b/buildscripts/setup_environment.sh
@@ -121,7 +121,7 @@ case $1 in
 #==========================================================================================
 "orion")
 
-    # Orion compiler modules define the environment variable MODULE so in order for
+    # Orion compiler modules define the environment variable COMPILER so in order for
     # the build scripts to function properly we need to replace it with something else
     cd ${JEDI_STACK_ROOT}/buildscripts
     sed -i -e 's/COMPILER/JEDI_COMPILER/g' setup_modules.sh build_stack.sh


### PR DESCRIPTION
Build jedi-stack on NOAA RDHPCS Orion at MSU.

Some notables:
- The stack has been built using native Intel 2019.5 and OpenMPI 4.0.2 compiler modules.
- PNetCDF needs to be updated to 1.12.1 for compatibility with OpenMPI 4.0.2
- IntelMPI has issues on Orion, so that stack is not built.
- This PR should not affect any other containers.