### PR TITLE
Add Atlas to jedi-stack

### DIFF
--- a/buildscripts/build_stack.sh
+++ b/buildscripts/build_stack.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # The purpose of this script is to build the software stack using
 # the compiler/MPI combination defined by setup_modules.sh
-# 
+#
 # Arguments:
-# configuration: Determines which libraries will be installed.  
-#     Each supported option will have an associated config_<option>.sh 
-#     file that will be used to 
+# configuration: Determines which libraries will be installed.
+#     Each supported option will have an associated config_<option>.sh
+#     file that will be used to
 #
 # sample usage:
 # build_stack.sh "container"
@@ -33,19 +33,19 @@ if [[ $# -ne 1 ]]; then
 else
     config_file="config/config_$1.sh"
     if [[ -e $config_file ]]; then
-	source $config_file
+        source $config_file
     else
-	set +x
-	echo "ERROR: CONFIG FILE $config_file DOES NOT EXIST!"
-	echo "Currently supported options: "
-	echo ${supported_options[*]}
-	exit 1
+        set +x
+        echo "ERROR: CONFIG FILE $config_file DOES NOT EXIST!"
+        echo "Currently supported options: "
+        echo ${supported_options[*]}
+        exit 1
     fi
 
     # Currently we do not use modules in the containers
     [[ $1 =~ ^container ]] && export MODULES=false || export MODULES=true
 
-fi    
+fi
 
 # Optionally exit on failure
 [[ $STACK_EXIT_ON_FAIL =~ [yYtT] ]] && set -e
@@ -124,6 +124,10 @@ $MODULES && (set +x; module purge; set -x)
 [[ $STACK_BUILD_FCKIT =~ [yYtT] ]] && \
     libs/build_fckit.sh "jcsda" "develop" 2>&1 | tee "$logdir/fckit.log"
 
+# The first argument is the source, either "ecmwf" or "jcsda" (fork)
+[[ $STACK_BUILD_ATLAS =~ [yYtT] ]] && \
+    libs/build_atlas.sh "ecmwf" "0.19.1" 2>&1 | tee "$logdir/atlas.log"
+
 [[ $STACK_BUILD_ODB      =~ [yYtT] ]] && \
     libs/build_odb.sh "0.18.1.r2" 2>&1 | tee "$logdir/odb.log"
 
@@ -187,7 +191,7 @@ $MODULES && (set +x; module purge; set -x)
 # ===============================================================================
 # optionally clean up
 [[ $MAKE_CLEAN =~ [yYtT] ]] && \
-	( $SUDO rm -rf ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}; $SUDO rm -rf $logdir )
+    ( $SUDO rm -rf ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}; $SUDO rm -rf $logdir )
 
 # ===============================================================================
 

--- a/buildscripts/config/config_cheyenne.sh
+++ b/buildscripts/config/config_cheyenne.sh
@@ -44,6 +44,7 @@ export        STACK_BUILD_NCO=Y
 export    STACK_BUILD_ECBUILD=Y
 export      STACK_BUILD_ECKIT=Y
 export      STACK_BUILD_FCKIT=N
+export      STACK_BUILD_ATLAS=N
 export        STACK_BUILD_ODB=N
 export        STACK_BUILD_ODC=Y
 export    STACK_BUILD_ODYSSEY=Y

--- a/buildscripts/config/config_container-clang-mpich-dev.sh
+++ b/buildscripts/config/config_container-clang-mpich-dev.sh
@@ -44,6 +44,7 @@ export        STACK_BUILD_NCO=Y
 export    STACK_BUILD_ECBUILD=Y
 export      STACK_BUILD_ECKIT=Y
 export      STACK_BUILD_FCKIT=N
+export      STACK_BUILD_ATLAS=N
 export        STACK_BUILD_ODB=N
 export        STACK_BUILD_ODC=N
 export    STACK_BUILD_ODYSSEY=N

--- a/buildscripts/config/config_container-gnu-openmpi-dev.sh
+++ b/buildscripts/config/config_container-gnu-openmpi-dev.sh
@@ -45,6 +45,7 @@ export        STACK_BUILD_NCO=Y
 export    STACK_BUILD_ECBUILD=Y
 export      STACK_BUILD_ECKIT=Y
 export      STACK_BUILD_FCKIT=N
+export      STACK_BUILD_ATLAS=N
 export        STACK_BUILD_ODB=N
 export        STACK_BUILD_ODC=N
 export    STACK_BUILD_ODYSSEY=N

--- a/buildscripts/config/config_container-intel-impi-dev.sh
+++ b/buildscripts/config/config_container-intel-impi-dev.sh
@@ -49,6 +49,7 @@ export        STACK_BUILD_NCO=N
 export    STACK_BUILD_ECBUILD=Y
 export      STACK_BUILD_ECKIT=Y
 export      STACK_BUILD_FCKIT=N
+export      STACK_BUILD_ATLAS=N
 export        STACK_BUILD_ODB=N
 export        STACK_BUILD_ODC=N
 export    STACK_BUILD_ODYSSEY=N

--- a/buildscripts/config/config_custom.sh
+++ b/buildscripts/config/config_custom.sh
@@ -22,7 +22,7 @@ export COMPILER_BUILD="native-pkg"
 export MPI_BUILD="from-source"
 
 # Build options
-export PREFIX=/opt/modules 
+export PREFIX=/opt/modules
 export USE_SUDO=Y
 export PKGDIR=pkg
 export LOGDIR=buildscripts/log
@@ -50,6 +50,7 @@ export        STACK_BUILD_NCO=N
 export    STACK_BUILD_ECBUILD=Y
 export      STACK_BUILD_ECKIT=N
 export      STACK_BUILD_FCKIT=N
+export      STACK_BUILD_ATLAS=N
 export        STACK_BUILD_ODB=N
 export        STACK_BUILD_ODC=Y
 export    STACK_BUILD_ODYSSEY=Y

--- a/buildscripts/config/config_mac.sh
+++ b/buildscripts/config/config_mac.sh
@@ -20,7 +20,7 @@ export MPI_BUILD="from-source"
 export MKDIR_P="mkdir -p"
 
 # Build options
-export PREFIX=/opt/modules 
+export PREFIX=/opt/modules
 export USE_SUDO=Y
 export PKGDIR=pkg
 export LOGDIR=buildscripts/log
@@ -49,6 +49,7 @@ export        STACK_BUILD_NCO=Y
 export    STACK_BUILD_ECBUILD=Y
 export      STACK_BUILD_ECKIT=Y
 export      STACK_BUILD_FCKIT=Y
+export      STACK_BUILD_ATLAS=Y
 export        STACK_BUILD_ODB=Y
 export        STACK_BUILD_ODC=Y
 export    STACK_BUILD_ODYSSEY=Y

--- a/buildscripts/libs/build_atlas.sh
+++ b/buildscripts/libs/build_atlas.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -ex
+
+name="atlas"
+# source should be either ecmwf or jcsda (fork)
+source=$1
+version=$2
+
+# Hyphenated version used for install prefix
+compiler=$(echo $COMPILER | sed 's/\//-/g')
+mpi=$(echo $MPI | sed 's/\//-/g')
+
+[[ $USE_SUDO =~ [yYtT] ]] && export SUDO="sudo" || unset SUDO
+[[ $MAKE_VERBOSE =~ [yYtT] ]] && verb="VERBOSE=1" || unset verb
+
+if $MODULES; then
+    set +x
+    source $MODULESHOME/init/bash
+    module load jedi-$COMPILER
+    module load jedi-$MPI
+    module load ecbuild eckit fckit
+    module list
+    set -x
+
+    prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$source-$version"
+    if [[ -d $prefix ]]; then
+  [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+    fi
+
+else
+    prefix=${ATLAS_ROOT:-"/usr/local"}
+fi
+
+
+export FC=$MPI_FC
+export CC=$MPI_CC
+export CXX=$MPI_CXX
+export F9X=$FC
+
+software=$name
+cd ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}
+
+[[ -d $software ]] || git clone https://github.com/$source/$software.git
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+git checkout $version
+[[ -d build ]] && $SUDO rm -rf build
+mkdir -p build && cd build
+
+ecbuild --prefix=$prefix --build=Release ..
+make -j${NTHREADS:-4}
+$SUDO make $verb install
+
+# generate modulefile from template
+$MODULES && update_modules mpi $name $source-$version \
+   || echo $name $source-$version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log
+
+exit 0

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/atlas/atlas.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/atlas/atlas.lua
@@ -1,0 +1,38 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,2)
+local mpiNameVer   = hierA[1]
+local compNameVer  = hierA[2]
+local mpiNameVerD  = mpiNameVer:gsub("/","-")
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+always_load("eckit")
+always_load("fckit")
+
+prereq("eckit")
+prereq("fckit")
+
+local opt = os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
+
+prepend_path("PATH", pathJoin(base,"bin"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("CPATH", pathJoin(base,"include"))
+prepend_path("MANPATH", pathJoin(base,"share","man"))
+
+setenv( "ATLAS_PATH", base)
+setenv( "ATLAS_VERSION", pkgVersion)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: Library")
+whatis("Description: ECMWF Atlas Library")


### PR DESCRIPTION
This PR adds an option to build ECMWF::atlas with the stack.
Currently building v0.19.1

@mmiesch I saw you had a branch, but rather that using that, I just copied `build_fckit.sh` to `build_atlas.sh` and made the necessary changes.
This version of build does not use all the bells and whistles that Atlas can use e.g. FFTW, CGAL, etc.
But, it works for the limited use we have, so far.
