### PR TITLE
Bugfix for modulepath setup

### DIFF
--- a/modulefiles/compiler/compilerName/compilerVersion/jedi-openmpi/jedi-openmpi.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/jedi-openmpi/jedi-openmpi.lua
@@ -18,7 +18,7 @@ prereq(mpi)
 
 local opt = os.getenv("OPT") or "/opt/modules"
 
-local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,"jedi-openmpi",pkgVersion)
+local mpath = pathJoin(opt,"modulefiles/mpi",compNameVer,"openmpi",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 
 setenv("MPI_FC",  "mpifort")

--- a/modulefiles/core/jedi-gnu/jedi-gnu.lua
+++ b/modulefiles/core/jedi-gnu/jedi-gnu.lua
@@ -16,7 +16,7 @@ prereq(compiler)
 
 local opt = os.getenv("OPT") or "/opt/modules"
 
-local mpath = pathJoin(opt,"modulefiles/compiler",pkgName,pkgVersion)
+local mpath = pathJoin(opt,"modulefiles/compiler","gnu",pkgVersion)
 prepend_path("MODULEPATH", mpath)
 
 setenv("FC",  "gfortran")


### PR DESCRIPTION
I wanted to update my gnu/openmpi modules and it took me two days to figure out why it was not working... Not in vain though: I now know how the modules system works!

I checked the equivalent files for other compilers, and this bugfix is consistent with all the other compilers/mpi wrappers.