### PR TITLE
Minor fixes for feature/hpc-updates on S4

### DIFF
--- a/buildscripts/config/config_S4.sh
+++ b/buildscripts/config/config_S4.sh
@@ -16,13 +16,13 @@ export JEDI_MPI="impi/19.0.5"
 #             This is a common option for, e.g., gcc/g++/gfortrant
 # from-source: This is to build from source
 export COMPILER_BUILD="native-pkg"
-export MPI_BUILD="from-source"
+export MPI_BUILD="native-pkg"
 # Build options
-export PREFIX=/data/users/mmiesch/modules-beta
+export PREFIX=${JEDI_STACK_PREFIX:-/data/users/$USER/modules}
 export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=buildscripts/log
-export OVERWRITE=N
+export OVERWRITE=Y
 export NTHREADS=4
 export   MAKE_CHECK=N
 export MAKE_VERBOSE=Y

--- a/buildscripts/libs/build_nccmp.sh
+++ b/buildscripts/libs/build_nccmp.sh
@@ -47,7 +47,7 @@ fi
 export CFLAGS+=" -fPIC"
 export LDFLAGS+=" -L$NETCDF_ROOT/lib -L$HDF5_ROOT/lib -L$SZIP_ROOT/lib"
 
-url="https://gitlab.com/remikz/nccmp/-/tree/$version/${software}.tar.gz"
+url="https://gitlab.com/remikz/nccmp/-/archive/$version/${software}.tar.gz"
 
 cd ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}
 


### PR DESCRIPTION
These changes made it easier to build.  
* The `setup_modules.sh` won't pass without `MPI_BUILD=native-pkg`
* The nccmp path has changed.
*  I added a mechanism to set the PREFIX overriding the hardecoded path.
* `OVERWRITE=Y` seems like a sensible default?  Otherwise I fail when I try to rebuild a package.

Finally a question.  I've got the stack built, but I'm missing the `modulefiles/core/jedi/intel-impi/` and the `modulesfiles/core/jedi/jedi-gcc` files.  It looks like the later should be installed by `setup_modules.sh S4`.  The former is out-of-date with respect to `modulefiles/apps/jedi/intel-impi.lua`.  I'm guessing this part is still customized for each machine?