### PR TITLE
add ecbuild dependency for jcsda

### DIFF
--- a/buildscripts/libs/build_fms.sh
+++ b/buildscripts/libs/build_fms.sh
@@ -21,6 +21,7 @@ if $MODULES; then
   module load jedi-$JEDI_COMPILER
   module load jedi-$JEDI_MPI
   module load netcdf
+  module try-load ecbuild
   module list
   set -x
 
@@ -52,11 +53,15 @@ software=$name-$version
 [[ -d build ]] && rm -rf build
 mkdir -p build && cd build
 
+if [[ ${source} == jcsda ]]; then
+  extra_conf="-DCMAKE_MODULE_PATH=${ECBUILD_DIR}"
+fi
+
 cmake .. \
       -DCMAKE_INSTALL_PREFIX=$prefix \
       -D32BIT=ON -D64BIT=ON \
       -DGFS_PHYS=ON \
-      -DLARGEFILE=ON
+      -DLARGEFILE=ON ${extra_conf}
 VERBOSE=$MAKE_VERBOSE make -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check
 $SUDO make install

--- a/modulefiles/core/ecbuild/ecbuild.lua
+++ b/modulefiles/core/ecbuild/ecbuild.lua
@@ -16,6 +16,7 @@ local base = pathJoin(opt,"core",pkgName,pkgVersion)
 prepend_path("PATH", pathJoin(base,"bin"))
 
 setenv("ECBUILD_PATH",base)
+setenv("ECBUILD_DIR", pathJoin(base,"share/ecbuild/cmake"))
 
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)


### PR DESCRIPTION
## Description

Bugfix to get the jcsda fork of fms to build, which requires ecbuild (unlike the noaa-gfdl source).

@markjolah - do I have the naming convention correct for` EBUILD_DIR`?

### Issue(s) addressed

This should solve the problems @rickgrubin was reporting
