### PR TITLE
DRAFT: Add option to use conda or classic Python in jedi-stack & unrelated updates and bug fixes

### DIFF
--- a/buildscripts/build_stack.sh
+++ b/buildscripts/build_stack.sh
@@ -73,6 +73,11 @@ mkdir -p $logdir
 $MODULES && (set +x;  source $MODULESHOME/init/bash; module purge; set -x)
 
 #----------------------
+# Prerequisite, must be built first so that
+# the Python-dependent builds (e.g. bufr) work
+build_lib PYJEDI pyjedi
+
+#----------------------
 # MPI-independent
 # - should add a check at some point to see if they are already there.
 # this can be done in each script individually
@@ -113,7 +118,6 @@ build_lib ARMADILLO armadillo 1.900.1
 build_lib XERCES xerces 3.1.4
 build_lib NCEPLIBS nceplibs fv3
 build_lib TKDIFF tkdiff 4.3.5
-build_lib PYJEDI pyjedi
 build_lib PYBIND11 pybind11 2.5.0
 build_lib GSL_LITE gsl_lite 0.37.0
 build_lib GEOS geos 3.8.1

--- a/buildscripts/config/choose_modules.sh
+++ b/buildscripts/config/choose_modules.sh
@@ -4,7 +4,8 @@
 # http://www.apache.org/licenses/LICENSE-2.0.
 
 # Minimal JEDI Stack
-export      STACK_BUILD_CMAKE=Y
+export     STACK_BUILD_PYJEDI=Y
+export      STACK_BUILD_CMAKE=N
 export     STACK_BUILD_GITLFS=N
 export       STACK_BUILD_SZIP=Y
 export    STACK_BUILD_UDUNITS=Y
@@ -29,7 +30,6 @@ export           STACK_BUILD_ODC=N
 export           STACK_BUILD_PIO=N
 export          STACK_BUILD_GPTL=N
 export           STACK_BUILD_NCO=N
-export        STACK_BUILD_PYJEDI=N
 export      STACK_BUILD_NCEPLIBS=N
 export          STACK_BUILD_JPEG=N
 export           STACK_BUILD_PNG=N

--- a/buildscripts/config/config_cheyenne.sh
+++ b/buildscripts/config/config_cheyenne.sh
@@ -6,25 +6,27 @@
 # Compiler/MPI combination
 #export JEDI_COMPILER="gnu/9.1.0"
 #export JEDI_MPI="openmpi/4.0.3"
-export JEDI_COMPILER="intel/19.0.5"
-export JEDI_MPI="impi/2019.6.154"
+export JEDI_COMPILER="intel/2021.2"
+export JEDI_MPI="impi/2021.2"
+export JEDI_PYTHON="conda/latest"
 
 # This tells jedi-stack how you want to build the compiler and mpi modules
 # valid options include:
 # native-module: load a pre-existing module (common for HPC systems)
 # native-pkg: use pre-installed executables located in /usr/bin or /usr/local/bin,
-#             as installed by package managers like apt-get or hombrewo.
-#             This is a common option for, e.g., gcc/g++/gfortrant
-# from-source: This is to build from source
-export JEDI_COMPILER_BUILD="native-module"
+#             as installed by package managers like apt-get or homebrew.
+#             This is a common option for, e.g., gcc/g++/gfortran
+# from-source: This is to build from source, not supported for Python
+export COMPILER_BUILD="native-module"
 export MPI_BUILD="native-module"
+export PYTHON_BUILD="native-module"
 
 # Build options
-export PREFIX=/glade/work/miesch/modules
+export PREFIX=${JEDI_OPT:-/glade/work/jedipara/cheyenne/opt/modules}
 export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=buildscripts/log
-export OVERWRITE=N
+export OVERWRITE=Y
 export NTHREADS=4
 export   MAKE_CHECK=N
 export MAKE_VERBOSE=Y
@@ -32,8 +34,15 @@ export   MAKE_CLEAN=N
 export DOWNLOAD_ONLY=F
 export STACK_EXIT_ON_FAIL=T
 export WGET="wget -nv"
-#Global compiler flags
+
+# Global compiler flags
 export FFLAGS=""
 export CFLAGS=""
 export CXXFLAGS="-gxx-name=/glade/u/apps/ch/opt/gnu/9.1.0/bin/g++ -Wl,-rpath,/glade/u/apps/ch/opt/gnu/9.1.0/lib64"
 export LDFLAGS="-gxx-name=/glade/u/apps/ch/opt/gnu/9.1.0/bin/g++ -Wl,-rpath,/glade/u/apps/ch/opt/gnu/9.1.0/lib64"
+
+# The nasty stuff ... get rid of the CISL compiler modules that interfere with our stack
+module purge
+module unuse /glade/u/apps/ch/modulefiles/default/compilers
+module use   /glade/p/ral/jntp/GMTB/tools/compiler_mpi_modules/compilers
+export MODULEPATH_ROOT=/glade/p/ral/jntp/GMTB/tools/compiler_mpi_modules

--- a/buildscripts/config/config_mac.sh
+++ b/buildscripts/config/config_mac.sh
@@ -5,19 +5,22 @@
 
 
 # Compiler/MPI combination
-export JEDI_COMPILER="clang/11.0.3"
+export JEDI_COMPILER="clang/13.0.0"
 export FC=gfortran #Set the initial fortran compiler to build MPI distribution
 #export JEDI_MPI="openmpi/4.0.3"
 export JEDI_MPI="mpich/3.3.2"
+export JEDI_PYTHON="python/3.9.9"
+
 # This tells jedi-stack how you want to build the compiler and mpi modules
 # valid options include:
 # native-module: load a pre-existing module (common for HPC systems)
 # native-pkg: use pre-installed executables located in /usr/bin or /usr/local/bin,
-#             as installed by package managers like apt-get or hombrewo.
-#             This is a common option for, e.g., gcc/g++/gfortrant
-# from-source: This is to build from source
+#             as installed by package managers like apt-get or homebrew.
+#             This is a common option for, e.g., gcc/g++/gfortran
+# from-source: This is to build from source, not supported for Python"
 export COMPILER_BUILD="native-pkg"
 export MPI_BUILD="from-source"
+export PYTHON_BUILD="native-pkg"
 
 #Determine number of processors: valid on OSX
 if [[ -x sysctl ]]; then
@@ -28,7 +31,7 @@ fi
 
 # Build options
 export PREFIX=${JEDI_OPT:-/opt/modules}
-export USE_SUDO=Y
+export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=buildscripts/log
 export OVERWRITE=Y
@@ -39,7 +42,8 @@ export   MAKE_CLEAN=N
 export DOWNLOAD_ONLY=F
 export STACK_EXIT_ON_FAIL=T
 export WGET="wget -nv"
-#Global compiler flags
+
+# Global compiler flags
 export FFLAGS=""
 export CFLAGS=""
 export CXXFLAGS=""

--- a/buildscripts/config/config_orion.sh
+++ b/buildscripts/config/config_orion.sh
@@ -5,21 +5,23 @@
 
 
 # Compiler/MPI combination
-export JEDI_COMPILER="intel/2020"
-export JEDI_MPI="impi/2020"
+export JEDI_COMPILER="intel/2020.2"
+export JEDI_MPI="impi/2020.2"
+export JEDI_PYTHON="python/3.9.2"
 
 # This tells jedi-stack how you want to build the compiler and mpi modules
 # valid options include:
 # native-module: load a pre-existing module (common for HPC systems)
 # native-pkg: use pre-installed executables located in /usr/bin or /usr/local/bin,
-#             as installed by package managers like apt-get or hombrewo.
-#             This is a common option for, e.g., gcc/g++/gfortrant
-# from-source: This is to build from source
-export JEDI_COMPILER_BUILD="native-module"
+#             as installed by package managers like apt-get or homebrew.
+#             This is a common option for, e.g., gcc/g++/gfortran
+# from-source: This is to build from source, not supported for Python"
+export COMPILER_BUILD="native-module"
 export MPI_BUILD="native-module"
+export PYTHON_BUILD="native-module"
 
 # Build options
-export PREFIX=/work/noaa/da/mmiesch/modules
+export PREFIX=${JEDI_OPT:-/work/noaa/da/jedipara/opt/modules}
 export USE_SUDO=N
 export PKGDIR=pkg
 export LOGDIR=buildscripts/log
@@ -31,8 +33,10 @@ export   MAKE_CLEAN=N
 export DOWNLOAD_ONLY=F
 export STACK_EXIT_ON_FAIL=T
 export WGET="wget -nv"
+
 #Global compiler flags
 export FFLAGS=""
 export CFLAGS=""
-export CXXFLAGS="-std=c++14"
-export LDFLAGS="-std=c++14"
+# These don't work for some of the packages (when the OS GNU compiler is used)
+#export CXXFLAGS="-std=c++14"
+#export LDFLAGS="-std=c++14"

--- a/buildscripts/libs/build_bufr.sh
+++ b/buildscripts/libs/build_bufr.sh
@@ -19,6 +19,7 @@ if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
     module load jedi-$JEDI_COMPILER
+    module load jedi-$JEDI_PYTHON
     module try-load cmake
     module list
     set -x

--- a/buildscripts/libs/build_cmake.sh
+++ b/buildscripts/libs/build_cmake.sh
@@ -29,7 +29,7 @@ fi
 software=$name-$version
 cd ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}
 url="https://cmake.org/files/v${version%.*}/$software.tar.gz"
-[[ -d $software ]] || ( $WGET $url; tar -xf $software.tar.gz )
+[[ -d $software ]] || ( rm -f $software.tar.gz; $WGET $url; tar -xf $software.tar.gz )
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 

--- a/buildscripts/libs/build_json.sh
+++ b/buildscripts/libs/build_json.sh
@@ -37,7 +37,7 @@ url="https://github.com/nlohmann/json/archive/$tarfile"
 [[ -d build ]] && rm -rf build
 mkdir -p build && cd build
 
-cmake .. -DCMAKE_INSTALL_PREFIX=$prefix -DJSON_BuildTests=$MAKE_CHECK
+cmake .. -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_INSTALL_LIBDIR=lib -DJSON_BuildTests=$MAKE_CHECK
 [[ $MAKE_CHECK =~ [yYtT] ]] && make test
 $SUDO make install
 

--- a/buildscripts/libs/build_netcdf.sh
+++ b/buildscripts/libs/build_netcdf.sh
@@ -156,6 +156,8 @@ software=$name-"cxx4"-$version
 mkdir -p build && cd build
 
 ../configure --prefix=$prefix
+# Bug fix for case-insensitive macOS file systems
+mv -v VERSION VERSION.txt
 
 make V=$MAKE_VERBOSE -j${NTHREADS:-4}
 [[ $MAKE_CHECK =~ [yYtT] ]] && make check

--- a/buildscripts/libs/build_pyjedi.sh
+++ b/buildscripts/libs/build_pyjedi.sh
@@ -9,22 +9,79 @@ set -ex
 
 name="pyjedi"
 
-[[ $USE_SUDO =~ [yYtT] ]] || ! $MODULES && prefix=${PYJEDI_ROOT:-"/usr/local"} \
-	                  || prefix="$HOME/.local"
+if [[ $MODULES ]]; then
+  set +x
+  source $MODULESHOME/init/bash
+  # Tell the module to skip activating the pyjedi
+  # environment, since it doesn't exist yet
+  #SKIP_ACTIVATE_PYJEDI="Y" module load jedi-$JEDI_PYTHON
+  module load jedi-$JEDI_PYTHON
+  module list
+  set -x
+fi
+
+# Convert pythonName to lower case, stay posix compliant
+pythonName=$(echo $JEDI_PYTHON | cut -d/ -f1 | tr '[:upper:]' '[:lower:]')
+pythonVersion=$(echo $JEDI_PYTHON | cut -d/ -f2)
+version=$pythonVersion
+
+# Skip version for now ...
+prefix="${PREFIX:-"/opt/modules"}/$name/$version"
+
+if [[ -d $prefix ]]; then
+    [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+                               || ( echo "ERROR: $prefix EXISTS, ABORT!"; exit 1 )
+fi
+
+# Are we using some flavor of conda or not?
+[[ ${pythonName} = *conda* ]] && USE_CONDA=true || USE_CONDA=false
+
+if [[ "$USE_CONDA" = true ]]; then
+  # For conda, use uppercase PREFIX, the environment gets installed in prefix=PREFIX/pyjedi
+  export CONDA_ENVS_PATH=$PREFIX
+  set +x
+  source ${CONDA_ROOT}/etc/profile.d/conda.sh
+  conda activate
+  $SUDO conda create --name pyjedi --yes
+  conda activate pyjedi
+  set -x
+else
+  # For pip, use lowercase prefix which is PREFIX/pyjedi
+  export PYTHONPATH="${prefix}:${PYTHONPATH}"
+fi
 
 #####################################################################
 # Python Package installs
 #####################################################################
 
-$SUDO python3 -m pip install -U pip setuptools
-$SUDO python3 -m pip install -U numpy
-$SUDO python3 -m pip install -U wheel netCDF4 matplotlib
-$SUDO python3 -m pip install -U pandas
-$SUDO python3 -m pip install -U pycodestyle
-$SUDO python3 -m pip install -U autopep8
-$SUDO python3 -m pip install -U cffi
-$SUDO python3 -m pip install -U pycparser
-$SUDO python3 -m pip install -U pytest
-$SUDO python3 -m pip install -U ford
-$SUDO python3 -m pip install -U xarray
-$SUDO python3 -m pip install -U pyodc
+if [[ "$USE_CONDA" = true ]]; then
+  $SUDO conda install numpy --yes
+  $SUDO conda install pandas --yes
+  $SUDO conda install pycodestyle --yes
+  $SUDO conda install autopep8 --yes
+  $SUDO conda install cffi --yes
+  $SUDO conda install pycparser --yes
+  $SUDO conda install pytest --yes
+  # Conda version of ford does not work with the latest Python, use conda's pip
+  $SUDO pip install ford
+  $SUDO conda install xarray --yes
+  # pyodc not available via conda channels, use conda's pip
+  $SUDO pip install pyodc
+else
+  $SUDO python3 -m pip install -t $prefix pip setuptools
+  $SUDO python3 -m pip install -t $prefix numpy
+  $SUDO python3 -m pip install -t $prefix wheel netCDF4 matplotlib
+  $SUDO python3 -m pip install -t $prefix pandas
+  $SUDO python3 -m pip install -t $prefix pycodestyle
+  $SUDO python3 -m pip install -t $prefix autopep8
+  $SUDO python3 -m pip install -t $prefix cffi
+  $SUDO python3 -m pip install -t $prefix pycparser
+  $SUDO python3 -m pip install -t $prefix pytest
+  $SUDO python3 -m pip install -t $prefix ford
+  $SUDO python3 -m pip install -t $prefix xarray
+  $SUDO python3 -m pip install -t $prefix pyodc
+fi
+
+# generate modulefile from template
+$MODULES && update_modules python $name $version \
+         || echo $software >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/buildscripts/libs/update_modules.sh
+++ b/buildscripts/libs/update_modules.sh
@@ -29,6 +29,9 @@ function update_modules {
         mpi      )
             tmpl_file=$JEDI_STACK_ROOT/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/$2/$2.lua
             to_dir=$OPT/modulefiles/mpi/$JEDI_COMPILER/$JEDI_MPI ;;
+        python  )
+            tmpl_file=$JEDI_STACK_ROOT/modulefiles/python/pythonName/pythonVersion/$2/$2.lua
+            to_dir=$OPT/modulefiles/python/$JEDI_PYTHON ;;
         *) echo "ERROR: INVALID MODULE PATH, ABORT!"; exit 1 ;;
     esac
 
@@ -152,6 +155,7 @@ function _initialize_prefix() {
             core) prefix="${PREFIX:-"/opt/modules"}/core/$name/$version";;
             compiler) prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version";;
             mpi) prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version";;
+            # python not yet implemented
         esac
         if [[ -d $prefix ]]; then
             [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!"; $SUDO rm -rf $prefix ) \
@@ -189,4 +193,5 @@ export -f build_lib
 export -f _initialize_prefix
 export -f initialize_prefix_core
 export -f initialize_prefix_compiler
+# Note: this isn't used anywhere
 export -f initialize_prefix_mpi

--- a/buildscripts/setup_modules.sh
+++ b/buildscripts/setup_modules.sh
@@ -61,9 +61,13 @@ compilerVersion=$(echo $JEDI_COMPILER | cut -d/ -f2)
 mpiName=$(echo $JEDI_MPI | cut -d/ -f1)
 mpiVersion=$(echo $JEDI_MPI | cut -d/ -f2)
 
+pythonName=$(echo $JEDI_PYTHON | cut -d/ -f1)
+pythonVersion=$(echo $JEDI_PYTHON | cut -d/ -f2)
+
 set +x
 echo "Compiler: $compilerName/$compilerVersion"
 echo "Mpi: $mpiName/$mpiVersion"
+echo "Python: $pythonName/$pythonVersion"
 set -x
 
 # install with root permissions?
@@ -77,6 +81,7 @@ set -x
 $SUDO mkdir -p $JEDI_OPT/modulefiles/core
 $SUDO mkdir -p $JEDI_OPT/modulefiles/compiler/$compilerName/$compilerVersion
 $SUDO mkdir -p $JEDI_OPT/modulefiles/mpi/$compilerName/$compilerVersion/$mpiName/$mpiVersion
+$SUDO mkdir -p $JEDI_OPT/modulefiles/python/$pythonName/$pythonVersion
 
 $SUDO mkdir -p $JEDI_OPT/modulefiles/core/jedi-$compilerName
 $SUDO cp $JEDI_STACK_ROOT/modulefiles/core/jedi-$compilerName/jedi-$compilerName.lua \
@@ -85,6 +90,10 @@ $SUDO cp $JEDI_STACK_ROOT/modulefiles/core/jedi-$compilerName/jedi-$compilerName
 $SUDO mkdir -p $JEDI_OPT/modulefiles/compiler/$compilerName/$compilerVersion/jedi-$mpiName
 $SUDO cp $JEDI_STACK_ROOT/modulefiles/compiler/compilerName/compilerVersion/jedi-$mpiName/jedi-$mpiName.lua \
          $JEDI_OPT/modulefiles/compiler/$compilerName/$compilerVersion/jedi-$mpiName/$mpiVersion.lua
+
+$SUDO mkdir -p $JEDI_OPT/modulefiles/core/jedi-$pythonName
+$SUDO cp $JEDI_STACK_ROOT/modulefiles/core/jedi-$pythonName/jedi-$pythonName.lua \
+         $JEDI_OPT/modulefiles/core/jedi-$pythonName/$pythonVersion.lua
 
 #===============================================================================
 # Make sure compiler is available
@@ -152,7 +161,7 @@ case ${MPI_BUILD} in
     set +x
     echo -e "==========================\n USING NATIVE MPI MODULE"
     source $MODULESHOME/init/bash
-    module load jedi-$JEDI_COMPILER
+    module load $JEDI_COMPILER
     module load $JEDI_MPI
     module list
     set -x
@@ -178,6 +187,31 @@ case ${MPI_BUILD} in
         exit $RetCode
     fi
     echo "MPI BUILD SUCCESS!"
+    ;;
+esac
+
+#===============================================================================
+# Make sure Python is available
+#
+
+case ${PYTHON_BUILD} in
+  "native-module")
+    echo -e "==========================\n USING NATIVE PYTHON MODULE"
+    set +x
+    source $MODULESHOME/init/bash
+    module load $JEDI_PYTHON
+    module list
+    set -x
+    ;;
+  "native-pkg")
+    echo -e "==========================\n USING NATIVE PYTHON"
+    cd $JEDI_OPT/modulefiles/core/jedi-$pythonName
+    $SUDO sed -i -e '/load(python)/d' $pythonVersion.lua
+    $SUDO sed -i -e '/prereq(python)/d' $pythonVersion.lua
+    ;;
+  "from-source")
+    echo "ERROR: INSTALLING PYTHON FROM SOURCE IS NOT SUPPORTED AT THIS TIME, ABORT!"
+    exit 1
     ;;
 esac
 

--- a/modulefiles/core/jedi-conda/jedi-conda.lua
+++ b/modulefiles/core/jedi-conda/jedi-conda.lua
@@ -25,9 +25,7 @@ whatis("Description: conda python configuration")
 local conda_dir = "${CONDA_ROOT}"
 local funcs = "conda __conda_activate __conda_hashr __conda_reactivate __add_sys_prefix_to_path"
 
--- On unload: Deactivate environment and remove exported functions
--- execute{cmd="for i in $(seq ${CONDA_SHLVL:=0}); do conda deactivate; done")
-execute{cmd="conda deactivate", modeA={"unload"}}
+-- On unload: Remove exported functions
 execute{cmd="unset -f " .. funcs, modeA={"unload"}}
 
 load(python)
@@ -38,9 +36,9 @@ setenv("CONDA_ENVS_PATH", opt)
 -- Directories are separated with a comma
 setenv("CONDA_PKGS_DIRS", conda_dir .. "/pkgs")
 
--- On load: Initialize conda and activate environment (unless told to skip)
+-- Set environment variable that tell JEDI python environments if this is conda or not
+setenv("JEDI_PYTHON_STYLE", "conda")
+
+-- On load: Initialize conda
 execute{cmd="source " .. conda_dir .. "/etc/profile.d/conda.sh; export -f " .. funcs, modeA={"load"}}
-local skip_activate=os.getenv("SKIP_ACTIVATE_PYJEDI") or ""
-if ( not skip_activate ) then
-  execute{cmd="conda activate pyjedi", modeA={"load"}}
-end
+

--- a/modulefiles/core/jedi-conda/jedi-conda.lua
+++ b/modulefiles/core/jedi-conda/jedi-conda.lua
@@ -1,0 +1,46 @@
+help([[
+JEDI conda python environment containing pyjedi
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+family("MetaPython")
+
+conflict(pkgName)
+conflict("jedi-conda", "jedi-python")
+
+local python = pathJoin("conda",pkgVersion)
+
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
+local mpath = pathJoin(opt,"modulefiles/python","conda",pkgVersion)
+prepend_path("MODULEPATH", mpath)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: python")
+whatis("Description: conda python configuration")
+
+local conda_dir = "${CONDA_ROOT}"
+local funcs = "conda __conda_activate __conda_hashr __conda_reactivate __add_sys_prefix_to_path"
+
+-- On unload: Deactivate environment and remove exported functions
+-- execute{cmd="for i in $(seq ${CONDA_SHLVL:=0}); do conda deactivate; done")
+execute{cmd="conda deactivate", modeA={"unload"}}
+execute{cmd="unset -f " .. funcs, modeA={"unload"}}
+
+load(python)
+prereq(python)
+
+-- Specify where system and user environments should be created
+setenv("CONDA_ENVS_PATH", opt)
+-- Directories are separated with a comma
+setenv("CONDA_PKGS_DIRS", conda_dir .. "/pkgs")
+
+-- On load: Initialize conda and activate environment (unless told to skip)
+execute{cmd="source " .. conda_dir .. "/etc/profile.d/conda.sh; export -f " .. funcs, modeA={"load"}}
+local skip_activate=os.getenv("SKIP_ACTIVATE_PYJEDI") or ""
+if ( not skip_activate ) then
+  execute{cmd="conda activate pyjedi", modeA={"load"}}
+end

--- a/modulefiles/core/jedi-python/jedi-python.lua
+++ b/modulefiles/core/jedi-python/jedi-python.lua
@@ -25,4 +25,6 @@ whatis("Description: non-conda python configuration")
 load(python)
 prereq(python)
 
-prepend_path("PYTHONPATH", opt .. "/modules/pyjedi")
+-- Set environment variable that tell JEDI python environments if this is conda or not
+setenv("JEDI_PYTHON_STYLE", "other")
+

--- a/modulefiles/core/jedi-python/jedi-python.lua
+++ b/modulefiles/core/jedi-python/jedi-python.lua
@@ -1,0 +1,28 @@
+help([[
+JEDI non-conda python environment containing pyjedi
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+family("MetaPython")
+
+conflict(pkgName)
+conflict("jedi-conda", "jedi-python")
+
+local python = pathJoin("python",pkgVersion)
+
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
+local mpath = pathJoin(opt,"modulefiles/python","python",pkgVersion)
+prepend_path("MODULEPATH", mpath)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: python")
+whatis("Description: non-conda python configuration")
+
+load(python)
+prereq(python)
+
+prepend_path("PYTHONPATH", opt .. "/modules/pyjedi")

--- a/modulefiles/python/pythonName/pythonVersion/pyjedi/pyjedi.lua
+++ b/modulefiles/python/pythonName/pythonVersion/pyjedi/pyjedi.lua
@@ -1,0 +1,39 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,1)
+local pythNameVer  = hierA[1]
+-- needed ??? 
+local pythNameVerD = pythNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,pkgName,pkgVersion)
+
+if (os.getenv("JEDI_PYTHON_STYLE")=="other") then
+  prepend_path("PATH",              pathJoin(base,"bin"))
+  prepend_path("LD_LIBRARY_PATH",   pathJoin(base))
+  prepend_path("DYLD_LIBRARY_PATH", pathJoin(base))
+  prepend_path("PYTHONPATH",        pathJoin(base))
+end
+
+if (os.getenv("JEDI_PYTHON_STYLE")=="conda") then
+  -- On load: Activate environment
+  execute{cmd="conda activate pyjedi", modeA={"load"}}
+  -- On unload: Deactivate environment
+  execute{cmd="conda deactivate", modeA={"unload"}}
+end
+
+-- prepend_path("CPATH", pathJoin(base,"include"))
+-- prepend_path("MANPATH", pathJoin(base,"share","man"))
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: PyJEDI Python environment")


### PR DESCRIPTION
## Description

Disclaimer: This PR is not supposed to be merged as is, since it combines unrelated changes in one PR. I needed to have all of them included so that I could test the development. Once we finished the discussion around the proposed changes, I will split the PR up into the different unrelated changes and create separate PRs in the correct order.

This PR:
- Introduces a jedi-python or, alternatively, a jedi-conda metamodule - to be discussed: should the meta module always be jedi-python?
- These metamodules can use "native-module" or "native-pkg" for the Python installation, "build-from-source" is not supported (yet - would that ever be an option?)
- Makes pyjedi the first package to install (this could be reverted, I made to change to highlight that this will probably be mandatory package going into the future)
- Builds pyjedi either for conda or classic python environments in `modules/pyjedi/...`, adds a pyjedi module that works with either classic python or conda
- Load jedi-python before building bufr
- Several small bug fixes that are unrelated to the Python changes
- Updates to the configs for Mac, Cheyenne, Orion - these are the three systems I used to test this PR
    - Mac: native-pkg (classic Python in /usr/bin)
    - Orion: native-module (classic Python module)
    - Cheyenne: native-module (conda module)

## Definition of Done

What does it mean for this issue to be done?  Is there a specific, measurable, milestone?

Done: a complete test on all systems that have a config file in the repository, plus the various containers in use

### Issue(s) addressed

jedi-stack doesn't have an issues page?

## Dependencies

If there are PRs that need to be merged before or along with this one, please add "waiting for another PR" label and list the dependencies in the other repositories (example below). Note that the branches in the other repositories should have matching names for the automated tests to pass.
Waiting on the following PRs:
- waiting on JCSDA/eckit/pull/<pr_number>
- waiting on JCSDA/atlas/pull/<pr_number>

## Impact

I don't know enough at this point to answer the impact questions.

If changes in this PR will affect other repositories, please add a "waiting for other repos" label, and list the repositories that will be affected to the best of your knowledge (example below).
Requires changes in the following repositories:
- [ ] saber
- [ ] ioda
- [ ] ufo
- [ ] ...

If changes in this PR require updating test data on AWS please add an "update test data" label and list the test data that needs to be updated to the best of your knowledge (example below).
Requires updating AWS test data for the following repositories:
- [ ] saber
- [ ] ioda
- [ ] ...

Note: to automatically run saber, ioda and ufo tests with this PR, push a commit containing "trigger pipeline", e.g.:
git commit --allow-empty -m 'trigger pipeline'
