### PR TITLE
Bug fix in tau2 lua module: add missing mpi hierarchy

### DIFF
--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/tau2/tau2.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/tau2/tau2.lua
@@ -5,15 +5,17 @@ local pkgName    = myModuleName()
 local pkgVersion = myModuleVersion()
 local pkgNameVer = myModuleFullName()
 
-local hierA        = hierarchyA(pkgNameVer,1)
-local compNameVer  = hierA[1]
+local hierA        = hierarchyA(pkgNameVer,2)
+local mpiNameVer   = hierA[1]
+local compNameVer  = hierA[2]
+local mpiNameVerD  = mpiNameVer:gsub("/","-")
 local compNameVerD = compNameVer:gsub("/","-")
 
 conflict(pkgName)
 
 local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
-local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
+local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
 
 prepend_path("LD_LIBRARY_PATH", pathJoin(base,"lib"))
 prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,"lib"))


### PR DESCRIPTION
## Description

The tau2 performance library depends on the choice of compiler and MPI library. The lua  module template however does not contain the mpi hierarchy.

## Definition of Done

Done: tau2 module file points to the correct install location, which is dependent on the compiler and MPI library.

### Issue(s) addressed

The "issues" feature has not been activated for jedi-stack in JCSDA-internal. Should it be activated?


## Dependencies

none

## Impact

none